### PR TITLE
chore: change header docs link

### DIFF
--- a/web/src/components/Header/index.tsx
+++ b/web/src/components/Header/index.tsx
@@ -75,7 +75,7 @@ const menus = [
   },
   {
     name: 'Docs',
-    url: 'https://github.com/nervosnetwork/docs',
+    url: 'https://docs.nervos.org/',
   },
 ]
 


### PR DESCRIPTION
change header docs link from https://github.com/nervosnetwork/docs
to https://docs.nervos.org/