### PR TITLE
fix: filter out pending transactions with dead cell-deps

### DIFF
--- a/app/workers/PoolTransactionCheckWorker.rb
+++ b/app/workers/PoolTransactionCheckWorker.rb
@@ -10,6 +10,12 @@ class PoolTransactionCheckWorker
           break
         end
       end
+      tx.cell_deps.each do |input|
+        if CellOutput.where(tx_hash: input["previous_output"]["tx_hash"], cell_index: input["previous_output"]["index"], status: "dead").exists?
+          pool_tx_entry_attributes << { id: tx.id, tx_status: "rejected", created_at: tx.created_at, updated_at: Time.current }
+          break
+        end
+      end
     end
 
     PoolTransactionEntry.upsert_all(pool_tx_entry_attributes) if pool_tx_entry_attributes.present?


### PR DESCRIPTION
A transaction with dead cell-deps should be treated as a double-spending transaction.

Due to my lack of familiarity with Ruby, I have not tested this change.