### PR TITLE
Feat 873 5

### DIFF
--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -614,6 +614,11 @@ module CkbSync
               udt_address_ids[tx_index] << attributes[4]
               contained_udt_ids[tx_index] << Udt.where(type_hash: attributes[3], udt_type: "sudt").pick(:id)
             end
+            if attributes[1][:cell_type] ==  "nrc_721_token"
+              tags[tx_index] << "nrc_721_token"
+              udt_address_ids[tx_index] << attributes[4]
+              contained_udt_ids[tx_index] << Udt.where(type_hash: attributes[3], udt_type: "nrc_721_token").pick(:id)
+            end
           end
           input_capacities[tx_index] += attributes[2] if tx_index != 0 && attributes[2].present?
         end

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -392,6 +392,14 @@ module CkbSync
             end
           end
           if cell_type == "nrc_721_token"
+            factory_cell = CkbUtils.parse_nrc_721_args(output.type.args)
+            nrc_721_factory_cell = NrcFactoryCell.find_or_create_by(code_hash: factory_cell.code_hash, hash_type: factory_cell.hash_type, args: factory_cell.args)
+            if nrc_721_factory_cell.verified
+              nft_token_attr[:full_name] = nrc_721_factory_cell.name
+              nft_token_attr[:symbol] = nrc_721_factory_cell.symbol
+              nft_token_attr[:icon_file] = "#{nrc_721_factory_cell.base_token_uri}/#{factory_cell.token_id}"
+              nft_token_attr[:nrc_factory_cell_id] = nrc_721_factory_cell.id
+            end
             nft_token_attr[:published] = true
           end
           # fill issuer_address after publish the token

--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -112,6 +112,7 @@ class CkbTransaction < ApplicationRecord
       display_output = { id: output.id, capacity: output.capacity, address_hash: output.address_hash, status: output.status, consumed_tx_hash: consumed_tx_hash, cell_type: output.cell_type }
       display_output.merge!(attributes_for_udt_cell(output)) if output.udt?
       display_output.merge!(attributes_for_m_nft_cell(output)) if output.cell_type.in?(%w(m_nft_issuer m_nft_class m_nft_token))
+      display_output.merge!(attributes_for_nrc_721_cell(output)) if output.cell_type.in?(%w(nrc_721_token nrc_721_factory))
 
       CkbUtils.hash_value_to_s(display_output)
     end
@@ -135,6 +136,7 @@ class CkbTransaction < ApplicationRecord
       display_input.merge!(attributes_for_dao_input(cell_outputs[index], false)) if previous_cell_output.nervos_dao_deposit?
       display_input.merge!(attributes_for_udt_cell(previous_cell_output)) if previous_cell_output.udt?
       display_input.merge!(attributes_for_m_nft_cell(previous_cell_output)) if previous_cell_output.cell_type.in?(%w(m_nft_issuer m_nft_class m_nft_token))
+      display_output.merge!(attributes_for_nrc_721_cell(previous_cell_output)) if previous_cell_output.cell_type.in?(%w(nrc_721_token nrc_721_factory))
 
       CkbUtils.hash_value_to_s(display_input)
     end
@@ -146,6 +148,10 @@ class CkbTransaction < ApplicationRecord
 
   def attributes_for_m_nft_cell(m_nft_cell)
     { m_nft_info: m_nft_cell.m_nft_info }
+  end
+
+  def attributes_for_nrc_721_cell(nrc_721_cell)
+    { m_nft_info: nrc_721_cell.nrc_721_nft_info }
   end
 
   def attributes_for_dao_input(nervos_dao_withdrawing_cell, is_phase2 = true)

--- a/app/models/nrc_factory_cell.rb
+++ b/app/models/nrc_factory_cell.rb
@@ -1,0 +1,23 @@
+class NrcFactoryCell < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: nrc_factory_cells
+#
+#  id             :bigint           not null, primary key
+#  code_hash      :binary
+#  hash_type      :string
+#  args           :string
+#  name           :string
+#  symbol         :string
+#  base_token_uri :string
+#  extra_data     :string
+#  verified       :boolean          default(FALSE)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_nrc_factory_cells_on_code_hash_and_hash_type_and_args  (code_hash,hash_type,args) UNIQUE
+#

--- a/app/models/udt.rb
+++ b/app/models/udt.rb
@@ -55,6 +55,7 @@ end
 #  block_timestamp        :decimal(30, )
 #  issuer_address         :binary
 #  ckb_transactions_count :decimal(30, )    default(0)
+#  nrc_factory_cell_id    :bigint
 #
 # Indexes
 #

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -41,7 +41,7 @@ class AddressSerializer
         elsif udt_account.udt_type == "m_nft_token"
           { symbol: udt_account.full_name, decimal: udt_account.decimal.to_s, amount: udt_account.amount.to_s, type_hash: udt_account.type_hash, udt_icon_file: udt_account.udt_icon_file, udt_type: udt_account.udt_type }
         elsif udt_account.udt_type == "nrc_721_token"
-          { symbol: udt_account.full_name, decimal: udt_account.decimal.to_s, amount: udt_account.nft_token_id.to_s, type_hash: udt_account.type_hash, udt_icon_file: udt_account.udt_icon_file, udt_type: udt_account.udt_type }
+          { symbol: udt_account.symbol, amount: udt_account.nft_token_id.to_s, type_hash: udt_account.type_hash, udt_icon_file: udt_account.udt_icon_file, udt_type: udt_account.udt_type }
         end
       end
     else

--- a/db/migrate/20220311140723_create_nrc_factory_cell.rb
+++ b/db/migrate/20220311140723_create_nrc_factory_cell.rb
@@ -1,0 +1,18 @@
+class CreateNrcFactoryCell < ActiveRecord::Migration[6.1]
+  def change
+    create_table :nrc_factory_cells do |t|
+      t.binary :code_hash
+      t.string :hash_type
+      t.string :args
+      t.string :name
+      t.string :symbol
+      t.string :base_token_uri
+      t.string :extra_data
+      t.boolean :verified, default: false
+
+      t.timestamps
+    end
+
+    add_index :nrc_factory_cells, [:code_hash, :hash_type, :args], unique: true
+  end
+end

--- a/db/migrate/20220311144809_add_nrc_factory_cell_id_to_udts.rb
+++ b/db/migrate/20220311144809_add_nrc_factory_cell_id_to_udts.rb
@@ -1,0 +1,5 @@
+class AddNrcFactoryCellIdToUdts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :udts, :nrc_factory_cell_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_16_063204) do
+ActiveRecord::Schema.define(version: 2022_03_11_144809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -373,6 +373,20 @@ ActiveRecord::Schema.define(version: 2022_02_16_063204) do
     t.index ["block_number"], name: "index_mining_infos_on_block_number"
   end
 
+  create_table "nrc_factory_cells", force: :cascade do |t|
+    t.binary "code_hash"
+    t.string "hash_type"
+    t.string "args"
+    t.string "name"
+    t.string "symbol"
+    t.string "base_token_uri"
+    t.string "extra_data"
+    t.boolean "verified", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["code_hash", "hash_type", "args"], name: "index_nrc_factory_cells_on_code_hash_and_hash_type_and_args", unique: true
+  end
+
   create_table "pool_transaction_entries", force: :cascade do |t|
     t.jsonb "cell_deps"
     t.binary "tx_hash"
@@ -473,6 +487,7 @@ ActiveRecord::Schema.define(version: 2022_02_16_063204) do
     t.decimal "block_timestamp", precision: 30
     t.binary "issuer_address"
     t.decimal "ckb_transactions_count", precision: 30, default: "0"
+    t.bigint "nrc_factory_cell_id"
     t.index ["type_hash"], name: "index_udts_on_type_hash", unique: true
   end
 

--- a/lib/tasks/migration/fill_nrc_721_token.rake
+++ b/lib/tasks/migration/fill_nrc_721_token.rake
@@ -2,12 +2,40 @@ namespace :migration do
   desc "Usage: RAILS_ENV=production bundle exec rake migration:update_nrc_721_token_info[factory_code_hash, factory_hash_type, factory_args]"
   task :update_nrc_721_token_info, [:factory_code_hash, :factory_hash_type, :factory_args]  => :environment do |_, args|
     factory_cell = NrcFactoryCell.find_by(code_hash: args[:factory_code_hash], hash_type: args[:factory_hash_type], args: args[:factory_args])
+
+    if factory_cell.nil?
+      puts "No Factory Cell Found!"
+      return
+    end
+
     nrc_721_factory_cell_type = TypeScript.where(code_hash: factory_cell.code_hash, hash_type: factory_cell.hash_type, args: factory_cell.args).first
     parsed_factory_data = CkbUtils.parse_nrc_721_factory_data(nrc_721_factory_cell.data)
     factory_cell.update(verified: true, name: parsed_factory_data.name, symbol: parsed_factory_data.symbol, base_token_uri: parsed_factory_data.base_token_uri, extra_data: parse_nrc_721_factory_data.extra_data)
     udts = Udt.where(nrc_factory_cell_id: factory_cell.id)
     udts.update_all(full_name: parsed_factory_data.name, symbol: parsed_factory_data.symbol, icon_file: "#{parsed_factory_data.base_token_uri}/#{factory_cell.token_id}")
     UdtAccount.where(udt_id: udts.pluck(:id)).update_all(full_name: parsed_factory_data.name, symbol: parsed_factory_data.symbol, icon_file: "#{parsed_factory_data.base_token_uri}/#{factory_cell.token_id}")
+    udts.each do |udt|
+      tx_ids = udt.ckb_transactions.pluck(:id)
+      tx_ids.each do |tx_id|
+        Rails.cache.delete("normal_tx_display_outputs_previews_false_#{tx_id}")
+        Rails.cache.delete("normal_tx_display_outputs_previews_true_#{tx_id}")
+        Rails.cache.delete("normal_tx_display_inputs_previews_false_#{tx_id}")
+        Rails.cache.delete("normal_tx_display_inputs_previews_true_#{tx_id}")
+        Rails.cache.delete("TxDisplayInfo/#{tx_id}")
+      end
+      TxDisplayInfoGeneratorWorker.new.perform(tx_ids)
+      # update udt transaction page cache
+      ckb_transactions = udt.ckb_transactions.select(:id, :tx_hash, :block_id, :block_number, :block_timestamp, :is_cellbase, :updated_at).recent.page(1).per(CkbTransaction.default_per_page)
+      Rails.cache.delete(ckb_transactions.cache_key)
+
+      # update addresses transaction page cache
+      CkbTransaction.where(id: tx_ids).find_each do |ckb_tx|
+        Address.where(id: ckb_tx.contained_address_ids).find_each do |address|
+          ckb_transactions = address.custom_ckb_transactions.select(:id, :tx_hash, :block_id, :block_number, :block_timestamp, :is_cellbase, :updated_at).recent.page(1).per(CkbTransaction.default_per_page)
+          $redis.del("#{ckb_transactions.cache_key}/#{address.query_address}")
+        end
+      end
+    end
   end
 
   desc "Usage: RAILS_ENV=production bundle exec rake migration:fill_old_nrc_721_token[0x7d77d51ba9a1123939de4ee06a86416f8edd747591aa3768426b3b199c2b4bd5]"


### PR DESCRIPTION
1. 新增一个 nrc_factory_cell 的表用于储存链上的factory cell
2. 当开发者提供factory cell 的时候，我们就运行` rake migration:update_nrc_721_token_info[factory_code_hash, factory_hash_type, factory_args]` 解析这个 factory cell 并标记verified
3. udt 会和 nrc_factory_cell  有个关联，每次都会检查这个factory cell 是否验证过，验证过就将识别出来的信息同步到 udt 表里