### PR TITLE
Fix udt insertion

### DIFF
--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -442,12 +442,20 @@ module CkbSync
             nft_token_attr[:published] = true
           end
           # fill issuer_address after publish the token
-          udts_attributes << {
-            type_hash: type_hash, udt_type: udt_type(cell_type), block_timestamp: local_block.timestamp, args: output.type.args,
-            code_hash: output.type.code_hash, hash_type: output.type.hash_type }.merge(nft_token_attr)
+          # udts_attributes << {
+          #   type_hash: type_hash, udt_type: udt_type(cell_type), block_timestamp: local_block.timestamp, args: output.type.args,
+          #   code_hash: output.type.code_hash, hash_type: output.type.hash_type }.merge(nft_token_attr)
+          Udt.create({
+            type_hash: type_hash, 
+            udt_type: udt_type(cell_type), 
+            block_timestamp: local_block.timestamp, 
+            args: output.type.args,
+            code_hash: output.type.code_hash, 
+            hash_type: output.type.hash_type 
+          }.merge(nft_token_attr))          
         end
       end
-      Udt.insert_all!(udts_attributes.map! { |attr| attr.merge!(created_at: Time.current, updated_at: Time.current) }) if udts_attributes.present?
+      # Udt.insert_all!(udts_attributes.map! { |attr| attr.merge!(created_at: Time.current, updated_at: Time.current) }) if udts_attributes.present?
     end
 
     def update_ckb_txs_rel_and_fee(ckb_txs, tags, input_capacities, output_capacities, udt_address_ids, dao_address_ids, contained_udt_ids, contained_addr_ids)

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -445,7 +445,7 @@ module CkbSync
           # udts_attributes << {
           #   type_hash: type_hash, udt_type: udt_type(cell_type), block_timestamp: local_block.timestamp, args: output.type.args,
           #   code_hash: output.type.code_hash, hash_type: output.type.hash_type }.merge(nft_token_attr)
-          Udt.create({
+          Udt.find_or_create_by!({
             type_hash: type_hash, 
             udt_type: udt_type(cell_type), 
             block_timestamp: local_block.timestamp, 


### PR DESCRIPTION
The UDT build codes may give `udt_attributes` different fields conditionally.
And rails cannot use `insert_all` for attributes with different keys in items.

So create UDT record one by one.