### PR TITLE
Do not use TxDisplayInfo cache

### DIFF
--- a/app/serializers/ckb_transaction_serializer.rb
+++ b/app/serializers/ckb_transaction_serializer.rb
@@ -53,11 +53,11 @@ class CkbTransactionSerializer
 
   attribute :income do |object, params|
     if params && params[:previews] && params[:address].present?
-      if object.tx_display_info.present?
-        object.tx_display_info.income[params[:address].address_hash]
-      else
+      # if object.tx_display_info.present?
+      #   object.tx_display_info.income[params[:address].address_hash]
+      # else
         object.income(params[:address])
-      end
+      # end
     end
   end
 end


### PR DESCRIPTION
because of address format change
The cached information stored in TxDisplayInfo model uses address hash as the cache key, so sometime the income cannot be found in TxDisplayInfo when the table store out dated data.