### PR TITLE
Fix/average dao deposit time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem "rack-attack"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "pry"
-  gem "pry-nav"
+  gem "pry-rails"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,8 +236,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-nav (0.3.0)
-      pry (>= 0.9.10, < 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (4.3.12)
       nio4r (~> 2.0)
@@ -424,7 +424,7 @@ DEPENDENCIES
   parallel
   pg (>= 0.18, < 2.0)
   pry
-  pry-nav
+  pry-rails
   puma (~> 4.3.12)
   rack-attack
   rack-cors

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -204,11 +204,12 @@ module CkbSync
         dao_inputs.each do |dao_input|
           previous_cell_output = CellOutput.where(id: dao_input.previous_cell_output_id).select(:address_id, :generated_by_id, :address_id, :dao, :cell_index, :capacity, :occupied_capacity).take!
           address = previous_cell_output.address
+          address.dao_deposit ||= 0
           if addrs_withdraw_info.key?(address.id)
             addrs_withdraw_info[address.id][:dao_deposit] -= previous_cell_output.capacity
           else
             addrs_withdraw_info[address.id] = {
-              dao_deposit: address.dao_deposit - previous_cell_output.capacity,
+              dao_deposit: address.dao_deposit.to_i - previous_cell_output.capacity,
               is_depositor: address.is_depositor,
               created_at: address.created_at
             }
@@ -550,7 +551,7 @@ module CkbSync
             nrc_721_factory_cell = NrcFactoryCell.find_or_create_by(code_hash: factory_cell.code_hash, hash_type: factory_cell.hash_type, args: factory_cell.args)
             if nrc_721_factory_cell.verified
               nft_token_attr[:full_name] = nrc_721_factory_cell.name
-              nft_token_attr[:symbol] = nrc_721_factory_cell.symbol.to_s[0,16]
+              nft_token_attr[:symbol] = nrc_721_factory_cell.symbol.to_s[0, 16]
               nft_token_attr[:icon_file] = "#{nrc_721_factory_cell.base_token_uri}/#{factory_cell.token_id}"
               nft_token_attr[:nrc_factory_cell_id] = nrc_721_factory_cell.id
             end

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -227,7 +227,7 @@ module CkbSync
             updated_at: Time.current
           }
           address_dao_deposit = Address.where(id: previous_cell_output.address_id).pick(:dao_deposit)
-          if (address_dao_deposit - previous_cell_output.capacity).zero?
+          if address_dao_deposit && (address_dao_deposit - previous_cell_output.capacity).zero?
             take_away_all_deposit_count += 1
             addrs_withdraw_info[address.id][:is_depositor] = false
             dao_events_attributes << {
@@ -242,6 +242,8 @@ module CkbSync
               created_at: Time.current,
               updated_at: Time.current
             }
+          else
+            puts "Cannot find address dao for #{previous_cell_output.address_id}"
           end
           withdraw_amount += previous_cell_output.capacity
           withdraw_transaction_ids << dao_input.ckb_transaction_id

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -313,10 +313,11 @@ module CkbSync
         deposit_dao_events_attributes = []
         dao_outputs.each do |dao_output|
           address = dao_output.address
+          address.dao_deposit ||= 0
           if addresses_deposit_info.key?(address.id)
             addresses_deposit_info[address.id][:dao_deposit] += dao_output.capacity
           else
-            addresses_deposit_info[address.id] = { dao_deposit: address.dao_deposit + dao_output.capacity, interest: address.interest, is_depositor: address.is_depositor, created_at: address.created_at }
+            addresses_deposit_info[address.id] = { dao_deposit: address.dao_deposit.to_i + dao_output.capacity, interest: address.interest, is_depositor: address.is_depositor, created_at: address.created_at }
           end
           if address.dao_deposit.zero? && !new_dao_depositors.key?(address.id)
             new_dao_depositors[address.id] = dao_output.ckb_transaction_id

--- a/app/workers/address_average_deposit_time_generator.rb
+++ b/app/workers/address_average_deposit_time_generator.rb
@@ -1,4 +1,8 @@
+# Refresh average deposit time for each address
+# average_deposit_time = Average locked duration of *each CKByte* in DAO Deposit
+# so we must sum the locked duration of all each CKByte in locked and unlocked deposit cells.
 class AddressAverageDepositTimeGenerator
+  MilliSecondsInDay = BigDecimal(24 * 60 * 60 * 1000).freeze
   include Sidekiq::Worker
 
   def perform
@@ -11,28 +15,22 @@ class AddressAverageDepositTimeGenerator
 
   private
 
-  def cal_average_deposit_time(address)
-    interest_bearing_deposits = 0
-    uninterest_bearing_deposits = 0
-    milliseconds_in_day = BigDecimal(24 * 60 * 60 * 1000)
-    ended_at = CkbUtils.time_in_milliseconds(Time.current)
-    sum_interest_bearing =
-      address.cell_outputs.nervos_dao_withdrawing.unconsumed_at(ended_at).reduce(0) do |memo, nervos_dao_withdrawing_cell|
-        nervos_dao_withdrawing_cell_generated_tx = nervos_dao_withdrawing_cell.generated_by
-        nervos_dao_deposit_cell = nervos_dao_withdrawing_cell_generated_tx.cell_inputs.order(:id)[nervos_dao_withdrawing_cell.cell_index].previous_cell_output
-        interest_bearing_deposits += nervos_dao_deposit_cell.capacity
-        memo + nervos_dao_deposit_cell.capacity * (nervos_dao_withdrawing_cell.block_timestamp - nervos_dao_deposit_cell.block_timestamp) / milliseconds_in_day
-      end
-    sum_uninterest_bearing =
-      address.cell_outputs.nervos_dao_deposit.unconsumed_at(ended_at).reduce(0) do |memo, nervos_dao_deposit_cell|
-        uninterest_bearing_deposits += nervos_dao_deposit_cell.capacity
+  # return average deposit time of specific address (unit in day)
+  def cal_average_deposit_time(address, ended_at = CkbUtils.time_in_milliseconds(Time.current))
+    total_ckb_deposit_time = 0 #   unlocked CKBs
+    total_deposits = 0 # locked CKBs
 
-        memo + nervos_dao_deposit_cell.capacity * (ended_at - nervos_dao_deposit_cell.block_timestamp) / milliseconds_in_day
-      end
+    # for unlocked deposit cell
+    # we must calculate the locked duration from lock to unlock.
+    # for locking deposit cell
+    # we calculate the locked duration from lock to now.
+    address.cell_outputs.nervos_dao_deposit.each do |cell|
+      total_deposits += cell.capacity
+      total_ckb_deposit_time += cell.capacity * ((cell.consumed_by_id ? cell.consumed_block_timestamp : ended_at) - cell.block_timestamp) / MilliSecondsInDay
+    end
 
-    total_deposits = interest_bearing_deposits + uninterest_bearing_deposits
     return 0 if total_deposits.zero?
 
-    ((sum_interest_bearing + sum_uninterest_bearing) / total_deposits).truncate(6)
+    (total_ckb_deposit_time / total_deposits).truncate(6)
   end
 end

--- a/app/workers/address_average_deposit_time_generator.rb
+++ b/app/workers/address_average_deposit_time_generator.rb
@@ -13,8 +13,6 @@ class AddressAverageDepositTimeGenerator
     end
   end
 
-  private
-
   # return average deposit time of specific address (unit in day)
   def cal_average_deposit_time(address, ended_at = CkbUtils.time_in_milliseconds(Time.current))
     total_ckb_deposit_time = 0 #   unlocked CKBs
@@ -26,11 +24,11 @@ class AddressAverageDepositTimeGenerator
     # we calculate the locked duration from lock to now.
     address.cell_outputs.nervos_dao_deposit.each do |cell|
       total_deposits += cell.capacity
-      total_ckb_deposit_time += cell.capacity * ((cell.consumed_by_id ? cell.consumed_block_timestamp : ended_at) - cell.block_timestamp) / MilliSecondsInDay
+      total_ckb_deposit_time += cell.capacity * ((cell.consumed_by_id ? cell.consumed_block_timestamp : ended_at) - cell.block_timestamp) 
     end
-
+    
     return 0 if total_deposits.zero?
 
-    (total_ckb_deposit_time / total_deposits).truncate(6)
+    (total_ckb_deposit_time / total_deposits / MilliSecondsInDay).truncate(6)
   end
 end


### PR DESCRIPTION
The calculating of average dao deposit lock time reckon without the idea that address of deposit dao cell can be different than the address of corresponding withdraw dao cell.