### PR TITLE
use materialized view to generate rolling average block time

### DIFF
--- a/app/controllers/api/v1/distribution_data_controller.rb
+++ b/app/controllers/api/v1/distribution_data_controller.rb
@@ -5,7 +5,15 @@ module Api
 
       def show
         if params[:id] == 'average_block_time'
-          render json: {data: {id: Time.current.to_i, type: "distribution_data", attributes: {average_block_time: DailyStatistic.full_average_block_time}}}
+          render json: {
+            data: {
+              id: Time.current.to_i, 
+              type: "distribution_data", 
+              attributes: {
+                average_block_time: RollingAvgBlockTime.all
+              }
+            }
+          }
         else
           distribution_data = DistributionData.new
           render json: DistributionDataSerializer.new(distribution_data, params: { indicator: params[:id] })

--- a/app/models/average_block_time_by_hour.rb
+++ b/app/models/average_block_time_by_hour.rb
@@ -1,0 +1,14 @@
+class AverageBlockTimeByHour < ApplicationRecord
+  self.table_name = 'average_block_time_by_hour'
+  def self.refresh
+    connection.execute "refresh materialized view average_block_time_by_hour CONCURRENTLY"
+  end
+end
+
+# == Schema Information
+#
+# Table name: average_block_time_by_hour
+#
+#  hour                    :datetime
+#  avg_block_time_per_hour :decimal(, )
+#

--- a/app/models/average_block_time_by_hour.rb
+++ b/app/models/average_block_time_by_hour.rb
@@ -1,3 +1,5 @@
+# This is a materialized view
+# The definition refers to db/migrate/20220705003300_create_average_block_time_by_hour_view.rb
 class AverageBlockTimeByHour < ApplicationRecord
   self.table_name = 'average_block_time_by_hour'
   def self.refresh

--- a/app/models/daily_statistic.rb
+++ b/app/models/daily_statistic.rb
@@ -17,27 +17,6 @@ class DailyStatistic < ApplicationRecord
   def liquidity
     circulating_supply - total_dao_deposit.to_d
   end
-
-  def self.full_average_block_time
-    first_time = order(id: :asc).first.created_at_unixtimestamp
-    last_rec = recent.first
-    last_time = last_rec.created_at_unixtimestamp
-    interval = 35.days
-    times = []
-    loop do
-      first_time += interval
-      if first_time <= last_time
-        times << first_time
-      else
-        break
-      end
-    end
-    records = where(created_at_unixtimestamp: times).pluck(:average_block_time).flatten.compact.sort{|i,j| i['timestamp'] <=> j['timestamp']}
-    if first_time > last_time
-      t = records.last['timestamp']
-      records += last_rec.average_block_time.reject{|i| i['timestamp'] <= t}
-    end
-  end
 end
 
 # == Schema Information

--- a/app/models/rolling_avg_block_time.rb
+++ b/app/models/rolling_avg_block_time.rb
@@ -1,0 +1,15 @@
+class RollingAvgBlockTime < ApplicationRecord
+  self.table_name = 'rolling_avg_block_time'
+  def self.refresh
+    connection.execute "refresh materialized view rolling_avg_block_time CONCURRENTLY"
+  end
+end
+
+# == Schema Information
+#
+# Table name: rolling_avg_block_time
+#
+#  timestamp             :integer
+#  avg_block_time_daily  :decimal(, )
+#  avg_block_time_weekly :decimal(, )
+#

--- a/app/models/rolling_avg_block_time.rb
+++ b/app/models/rolling_avg_block_time.rb
@@ -1,3 +1,5 @@
+# This is a materialized view
+# The definition refers to db/migrate/20220705003300_create_average_block_time_by_hour_view.rb
 class RollingAvgBlockTime < ApplicationRecord
   self.table_name = 'rolling_avg_block_time'
   def self.refresh

--- a/app/workers/average_block_time_generator.rb
+++ b/app/workers/average_block_time_generator.rb
@@ -1,3 +1,4 @@
+# refresh materialized views periodically
 class AverageBlockTimeGenerator
   include Sidekiq::Worker
 

--- a/app/workers/average_block_time_generator.rb
+++ b/app/workers/average_block_time_generator.rb
@@ -2,6 +2,7 @@ class AverageBlockTimeGenerator
   include Sidekiq::Worker
 
   def perform
-    BlockTimeStatistic.new.generate_daily
+    AverageBlockTimeByHour.refresh
+    RollingAvgBlockTime.refresh
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -27,7 +27,7 @@ cal_address_average_deposit_time:
   class: "AddressAverageDepositTimeGenerator"
 
 cal_average_block_time:
-  cron: "3 0 * * *"
+  cron: "0 * * * *"
   class: "AverageBlockTimeGenerator"
 
 cal_address_unclaimed_compensation:

--- a/db/migrate/20220705003300_create_average_block_time_by_hour_view.rb
+++ b/db/migrate/20220705003300_create_average_block_time_by_hour_view.rb
@@ -1,0 +1,28 @@
+class CreateAverageBlockTimeByHourView < ActiveRecord::Migration[6.1]
+  def self.up
+    execute <<-sql
+CREATE MATERIALIZED VIEW IF NOT EXISTS average_block_time_by_hour
+AS
+ SELECT date_trunc('hour'::text, to_timestamp((blocks."timestamp" / 1000.0)::double precision)) AS hour,
+    avg(blocks.block_time) AS avg_block_time_per_hour
+   FROM blocks
+  GROUP BY (date_trunc('hour'::text, to_timestamp((blocks."timestamp" / 1000.0)::double precision)))
+WITH DATA;
+sql
+
+    execute <<-sql
+CREATE MATERIALIZED VIEW IF NOT EXISTS rolling_avg_block_time
+TABLESPACE pg_default
+AS
+ SELECT EXTRACT(EPOCH FROM average_block_time_by_hour.hour)::integer as timestamp,
+    avg(average_block_time_by_hour.avg_block_time_per_hour) OVER (ORDER BY average_block_time_by_hour.hour ROWS BETWEEN 24 PRECEDING AND CURRENT ROW) AS avg_block_time_daily,
+    avg(average_block_time_by_hour.avg_block_time_per_hour) OVER (ORDER BY average_block_time_by_hour.hour ROWS BETWEEN (7 * 24) PRECEDING AND CURRENT ROW) AS avg_block_time_weekly
+   FROM average_block_time_by_hour
+WITH DATA;
+sql
+  end
+
+  def self.down
+    execute "DROP MATERIALIZED VIEW IF EXISTS rolling_avg_block_time, average_block_time_by_hour"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_11_181425) do
+ActiveRecord::Schema.define(version: 2022_03_11_144809) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "btree_gin"
   enable_extension "plpgsql"
 
   create_table "account_books", force: :cascade do |t|
@@ -94,6 +93,7 @@ ActiveRecord::Schema.define(version: 2022_07_11_181425) do
     t.integer "proposals_count"
     t.decimal "cell_consumed", precision: 30
     t.binary "miner_hash"
+    t.string "miner_message"
     t.decimal "reward", precision: 30
     t.decimal "total_transaction_fee", precision: 30
     t.decimal "ckb_transactions_count", precision: 30, default: "0"
@@ -120,7 +120,6 @@ ActiveRecord::Schema.define(version: 2022_07_11_181425) do
     t.integer "block_size"
     t.decimal "proposal_reward", precision: 30
     t.decimal "commit_reward", precision: 30
-    t.string "miner_message"
     t.jsonb "extension"
     t.index ["block_hash"], name: "index_blocks_on_block_hash", unique: true
     t.index ["block_size"], name: "index_blocks_on_block_size"
@@ -162,7 +161,7 @@ ActiveRecord::Schema.define(version: 2022_07_11_181425) do
     t.integer "data_size"
     t.decimal "occupied_capacity", precision: 30
     t.decimal "block_timestamp", precision: 30
-    t.decimal "consumed_block_timestamp", precision: 30, default: "0"
+    t.decimal "consumed_block_timestamp", precision: 30
     t.string "type_hash"
     t.decimal "udt_amount", precision: 40
     t.string "dao"
@@ -203,7 +202,6 @@ ActiveRecord::Schema.define(version: 2022_07_11_181425) do
     t.bigint "udt_address_ids", default: [], array: true
     t.index ["block_id", "block_timestamp"], name: "index_ckb_transactions_on_block_id_and_block_timestamp"
     t.index ["block_timestamp", "id"], name: "index_ckb_transactions_on_block_timestamp_and_id", order: { block_timestamp: "DESC NULLS LAST", id: :desc }
-    t.index ["contained_address_ids", "id"], name: "index_ckb_transactions_on_contained_address_ids_and_id", using: :gin
     t.index ["contained_address_ids"], name: "index_ckb_transactions_on_contained_address_ids", using: :gin
     t.index ["contained_udt_ids"], name: "index_ckb_transactions_on_contained_udt_ids", using: :gin
     t.index ["dao_address_ids"], name: "index_ckb_transactions_on_dao_address_ids", using: :gin
@@ -418,46 +416,6 @@ ActiveRecord::Schema.define(version: 2022_07_11_181425) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["table_name", "count"], name: "index_table_record_counts_on_table_name_and_count"
-  end
-
-  create_table "token_collections", force: :cascade do |t|
-    t.string "standard"
-    t.string "name"
-    t.text "description"
-    t.integer "creator_id"
-    t.string "icon_url"
-    t.integer "items_count"
-    t.integer "holders_count"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "token_items", force: :cascade do |t|
-    t.integer "collection_id"
-    t.string "token_id"
-    t.string "name"
-    t.string "icon_url"
-    t.integer "owner_id"
-    t.string "metadata_url"
-    t.integer "cell_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["cell_id"], name: "index_token_items_on_cell_id"
-    t.index ["collection_id", "token_id"], name: "index_token_items_on_collection_id_and_token_id", unique: true
-    t.index ["owner_id"], name: "index_token_items_on_owner_id"
-  end
-
-  create_table "token_transfers", force: :cascade do |t|
-    t.integer "item_id"
-    t.integer "from_id"
-    t.integer "to_id"
-    t.integer "transaction_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["from_id"], name: "index_token_transfers_on_from_id"
-    t.index ["item_id"], name: "index_token_transfers_on_item_id"
-    t.index ["to_id"], name: "index_token_transfers_on_to_id"
-    t.index ["transaction_id"], name: "index_token_transfers_on_transaction_id"
   end
 
   create_table "transaction_propagation_delays", force: :cascade do |t|

--- a/test/services/charts/daily_statistic_generator_test.rb
+++ b/test/services/charts/daily_statistic_generator_test.rb
@@ -35,12 +35,5 @@ module Charts
       end
     end
 
-    test "average_block_time should return 840 points" do
-      1000.times do |number|
-        create(:block_time_statistic, stat_timestamp: 35.days.ago.end_of_day.to_i + number)
-      end
-      daily_generator = Charts::DailyStatisticGenerator.new
-      assert_equal 24 * 35, daily_generator.send(:average_block_time).count
-    end
   end
 end


### PR DESCRIPTION
The previous way to generate rolling average block time statistics is manually aggregate data from database using rails code.
Now I take advantage of Materialized View to generate statistics from the database level, so that the source codes can be simplified.
And the ancient data can be rebuilt directly.