### PR TITLE
create index for ckb transaction to optimize performance

### DIFF
--- a/app/models/cell_output.rb
+++ b/app/models/cell_output.rb
@@ -193,7 +193,7 @@ end
 #  data_size                :integer
 #  occupied_capacity        :decimal(30, )
 #  block_timestamp          :decimal(30, )
-#  consumed_block_timestamp :decimal(30, )
+#  consumed_block_timestamp :decimal(30, )    default(0)
 #  type_hash                :string
 #  udt_amount               :decimal(40, )
 #  dao                      :string

--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -231,6 +231,7 @@ end
 #  index_ckb_transactions_on_block_id_and_block_timestamp  (block_id,block_timestamp)
 #  index_ckb_transactions_on_block_timestamp_and_id        (block_timestamp DESC NULLS LAST,id DESC)
 #  index_ckb_transactions_on_contained_address_ids         (contained_address_ids) USING gin
+#  index_ckb_transactions_on_contained_address_ids_and_id  (contained_address_ids,id) USING gin
 #  index_ckb_transactions_on_contained_udt_ids             (contained_udt_ids) USING gin
 #  index_ckb_transactions_on_dao_address_ids               (dao_address_ids) USING gin
 #  index_ckb_transactions_on_is_cellbase                   (is_cellbase)

--- a/db/migrate/20220711181425_add_contained_address_ids_index_to_ckb_transactions.rb
+++ b/db/migrate/20220711181425_add_contained_address_ids_index_to_ckb_transactions.rb
@@ -1,0 +1,7 @@
+class AddContainedAddressIdsIndexToCkbTransactions < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+  def change
+    execute 'create extension btree_gin'
+    add_index :ckb_transactions, [:contained_address_ids, :id], using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20220711183054_remove_old_contained_address_ids_index_from_ckb_transactions.rb
+++ b/db/migrate/20220711183054_remove_old_contained_address_ids_index_from_ckb_transactions.rb
@@ -1,0 +1,5 @@
+class RemoveOldContainedAddressIdsIndexFromCkbTransactions < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :ckb_transactions, :contained_address_ids
+  end
+end


### PR DESCRIPTION
Some addresses contains too many transactions ( > 100000), cause pagination very slow.
I create a new union index to cover filtering and ordering to optimize that performance.
