### PR TITLE
Use AccountBook intermediate table to optimize transaction query on specific address.

### DIFF
--- a/app/models/account_book.rb
+++ b/app/models/account_book.rb
@@ -10,11 +10,9 @@ end
 #  id                 :bigint           not null, primary key
 #  address_id         :bigint
 #  ckb_transaction_id :bigint
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
 #
 # Indexes
 #
-#  index_account_books_on_address_id          (address_id)
-#  index_account_books_on_ckb_transaction_id  (ckb_transaction_id)
+#  index_account_books_on_address_id_and_ckb_transaction_id  (address_id,ckb_transaction_id) UNIQUE
+#  index_account_books_on_ckb_transaction_id                 (ckb_transaction_id)
 #

--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -7,7 +7,7 @@ class CkbTransaction < ApplicationRecord
   enum tx_status: { pending: 0, proposed: 1, committed: 2 }, _prefix: :ckb_transaction
 
   belongs_to :block
-  has_many :account_books, dependent: :destroy
+  has_many :account_books, dependent: :delete_all
   has_many :addresses, through: :account_books
   has_many :cell_inputs, dependent: :delete_all
   has_many :cell_outputs, dependent: :delete_all
@@ -228,9 +228,9 @@ end
 #
 # Indexes
 #
+#  alter_pk                                                (id,contained_address_ids) USING gin
 #  index_ckb_transactions_on_block_id_and_block_timestamp  (block_id,block_timestamp)
 #  index_ckb_transactions_on_block_timestamp_and_id        (block_timestamp DESC NULLS LAST,id DESC)
-#  index_ckb_transactions_on_contained_address_ids         (contained_address_ids) USING gin
 #  index_ckb_transactions_on_contained_address_ids_and_id  (contained_address_ids,id) USING gin
 #  index_ckb_transactions_on_contained_udt_ids             (contained_udt_ids) USING gin
 #  index_ckb_transactions_on_dao_address_ids               (dao_address_ids) USING gin

--- a/db/migrate/20220716080815_create_ckb_transaction_account_book_trigger.rb
+++ b/db/migrate/20220716080815_create_ckb_transaction_account_book_trigger.rb
@@ -1,0 +1,114 @@
+
+class CreateCkbTransactionAccountBookTrigger < ActiveRecord::Migration[6.1]
+  def self.up
+    execute 'TRUNCATE account_books'
+    # remove unused fields
+    remove_column :account_books, :created_at
+    remove_column :account_books, :updated_at
+    # add new index
+    add_index :account_books, [:address_id, :ckb_transaction_id], :unique => true
+    # remove old index
+    remove_index :account_books, :address_id
+
+    # create util function
+    execute <<-sql
+CREATE OR REPLACE FUNCTION array_subtract(
+	minuend anyarray,
+	subtrahend anyarray,
+	OUT difference anyarray)
+    RETURNS anyarray
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE STRICT PARALLEL UNSAFE
+AS $BODY$
+begin
+    execute 'select array(select unnest($1) except select unnest($2))'
+      using minuend, subtrahend
+       into difference;
+end;
+$BODY$;
+    sql
+    # create trigger function
+    execute <<-sql
+CREATE OR REPLACE FUNCTION synx_tx_to_account_book()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE NOT LEAKPROOF
+AS $BODY$
+DECLARE
+  i int;
+  to_add int[];
+  to_remove int[];
+   BEGIN
+   RAISE NOTICE 'trigger ckb tx(%)', new.id;
+   if new.contained_address_ids is null then
+   	new.contained_address_ids := array[]::int[];
+	end if;
+	if old is null 
+	then
+		to_add := new.contained_address_ids;
+		to_remove := array[]::int[];
+	else
+	
+	   to_add := array_subtract(new.contained_address_ids, old.contained_address_ids);
+	   to_remove := array_subtract(old.contained_address_ids, new.contained_address_ids);	
+	end if;
+
+   if to_add is not null then
+	   FOREACH i IN ARRAY to_add
+	   LOOP 
+	   	RAISE NOTICE 'ckb_tx_addr_id(%)', i;
+			insert into account_books (ckb_transaction_id, address_id) 
+			values (new.id, i);
+	   END LOOP;
+	end if;
+	if to_remove is not null then
+	   delete from account_books where ckb_transaction_id = new.id and address_id = ANY(to_remove);
+	end if;
+      RETURN NEW;
+   END;
+$BODY$;
+    sql
+
+    execute "DROP TRIGGER IF EXISTS sync_to_account_book ON ckb_transactions"
+    # create trigger
+    execute <<-sql
+    CREATE TRIGGER sync_to_account_book
+    AFTER INSERT OR UPDATE 
+    ON ckb_transactions
+    FOR EACH ROW
+    EXECUTE FUNCTION synx_tx_to_account_book();
+    sql
+
+    # create migration procedure
+    execute <<-sql
+CREATE OR REPLACE PROCEDURE sync_full_account_book(
+	)
+LANGUAGE 'plpgsql'
+AS $BODY$
+declare
+    c cursor for select * from ckb_transactions;
+    i int;
+     row  RECORD;
+begin
+    open c;
+    LOOP
+      FETCH FROM c INTO row;
+      EXIT WHEN NOT FOUND;
+      foreach i in array row.contained_address_ids loop
+        insert into account_books (ckb_transaction_id, address_id)
+        values (row.id, i) ON CONFLICT DO NOTHING;
+        end loop;
+    END LOOP;    
+    close c;
+end
+$BODY$;
+  sql
+
+    execute 'CALL sync_full_account_book()'
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Some address contains too many transactions. And the current indexes cannot cover this scenario.
`contained_address_ids` column in `ckb_transactions` table is an array type column, and the index on this column cannot combine with other simple column to both cover sorting and filtering.

So I reuse previous deprecated `account_books` intermediate table, which setup association between `ckb_transactions` and  `addresses`. And make composite indexes in this table to cover both address filtering and ckb transaction sorting .

However, in order to make minimum modifitication and not to introduce new bugs, I use table trigger in Postgresql to synchonize between `ckb_transactions.contained_address_ids` column and `account_books` table. So I can keep current block synchronization process untouched and only use this table in corresponding API request processing.

Now the corresponding SQL query can bew lowered to 1 second.