### PR TITLE
Support query transaction against too long address

### DIFF
--- a/app/controllers/api/v1/ckb_transactions_controller.rb
+++ b/app/controllers/api/v1/ckb_transactions_controller.rb
@@ -24,6 +24,29 @@ module Api
         end
       end
 
+      def query
+        @page = params[:page]
+        @page_size = params[:page_size]
+        if params[:address]
+          @address = Address.cached_find(params[:address])
+        end
+
+        ckb_transactions =
+          if @address
+            @scope = @scope.where
+            @tx_ids = AccountBook.where(address_id: @address.id).order("ckb_transaction_id" => :desc).select("ckb_transaction_id").page(@page).per(@page_size)
+            CkbTransaction.where(id: @tx_ids.map(&:ckb_transaction_id)).select(:id, :tx_hash, :block_id, :block_number, :block_timestamp, :is_cellbase, :updated_at).order(id: :desc)
+          else
+            CkbTransaction.recent.normal.page(@page).per(@page_size).select(:id, :tx_hash, :block_number, :block_timestamp, :live_cell_changes, :capacity_involved, :updated_at)
+          end
+        Rails.cache.realize(ckb_transactions.cache_key, version: ckb_transactions.cache_version, race_condition_ttl: 3.seconds) do
+          records_counter = RecordCounters::Transactions.new
+          options = FastJsonapi::PaginationMetaGenerator.new(request: request, records: ckb_transactions, page: @page, page_size: @page_size, records_counter: records_counter).call
+          CkbTransactionListSerializer.new(ckb_transactions, options).serialized_json
+        end
+        render json: json
+      end
+
       def show
         ckb_transaction = CkbTransaction.cached_find(params[:id]) || PoolTransactionEntry.find_by(tx_hash: params[:id])
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :addresses, only: :show
       get "/transactions/:id", to: "ckb_transactions#show", as: "ckb_transaction"
       get "/transactions", to: "ckb_transactions#index", as: "ckb_transactions"
+      post "/transactions/query", to: "ckb_transactions#query", as: "query_ckb_transactions"
       resources :cell_input_lock_scripts, only: :show
       resources :cell_input_type_scripts, only: :show
       resources :cell_input_data, only: :show

--- a/test/controllers/api/v1/ckb_transactions_controller_test.rb
+++ b/test/controllers/api/v1/ckb_transactions_controller_test.rb
@@ -339,7 +339,7 @@ module Api
         address = create(:address, :with_transactions)
         ckb_transactions = address.ckb_transactions.order(block_timestamp: :desc).page(page).per(page_size)
 
-        valid_post api_v1_query_transactions_url, address: address.address_hash
+        valid_post api_v1_query_ckb_transactions_url, params: {address: address.address_hash}
 
         records_counter = RecordCounters::AddressTransactions.new(address)
         options = FastJsonapi::PaginationMetaGenerator.new(request: request, records: ckb_transactions, page: page, page_size: page_size, records_counter: records_counter).call

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -394,7 +394,7 @@ module RequestHelpers
   def valid_post(uri, **params)
     params[:params] ||= {}
     params[:headers] = { "Content-Type": "application/vnd.api+json", "Accept": "application/vnd.api+json" }
-    post uri, params: params
+    post uri, as: :json, **params
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -153,119 +153,119 @@ end
 def fake_node_block(block_hash = DEFAULT_NODE_BLOCK_HASH, number = "0xc")
   CkbSync::Api.any_instance.stubs(:get_tip_block_number).returns(DEFAULT_NODE_BLOCK_NUMBER + 1)
   json_block = {
-      "header":{
-        "dao":"0x01000000000000000000c16ff286230000a3a65e97fd03000057c138586f0000",
-        "compact_target":"0x1000",
-        "epoch":"0x0",
-        "hash": block_hash,
-        "number": number,
-        "parent_hash":"0x598315db9c7ba144cca74d2e9122ac9b3a3da1641b2975ae321d91ec34f1c0e3",
-        "proposals_hash":"0x0000000000000000000000000000000000000000000000000000000000000000",
-        "nonce":"0x2cfb33aba57e0338",
-        "timestamp":"0x16aa12ea9e3",
-        "transactions_root":"0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6bf3",
-        "extra_hash":"0x0000000000000000000000000000000000000000000000000000000000000000",
-        "version":"0x0"
-      },
-      "proposals":[],
-      "transactions":
+    "header": {
+      "dao": "0x01000000000000000000c16ff286230000a3a65e97fd03000057c138586f0000",
+      "compact_target": "0x1000",
+      "epoch": "0x0",
+      "hash": block_hash,
+      "number": number,
+      "parent_hash": "0x598315db9c7ba144cca74d2e9122ac9b3a3da1641b2975ae321d91ec34f1c0e3",
+      "proposals_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "nonce": "0x2cfb33aba57e0338",
+      "timestamp": "0x16aa12ea9e3",
+      "transactions_root": "0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6bf3",
+      "extra_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "version": "0x0"
+    },
+    "proposals": [],
+    "transactions":
       [
         {
-          "header_deps":[],
-          "cell_deps":[],
-          "outputs_data":["0x"],
-          "hash":"0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6bf3",
-          "inputs":[
+          "header_deps": [],
+          "cell_deps": [],
+          "outputs_data": ["0x"],
+          "hash": "0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6bf3",
+          "inputs": [
             {
-              "previous_output": {"tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000", "index": "0x0"},
-              "since":"0x0"
+              "previous_output": { "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000", "index": "0x0" },
+              "since": "0x0"
             }
           ],
-          "outputs":[
+          "outputs": [
             {
-              "capacity":"0x23c34600",
-              "data":"0x",
-              "lock":{
-                "args":"0xb2e61ff569acf041b3c2c17724e2379c581eeac3",
-                "code_hash":"0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794",
-                "hash_type":"data"
+              "capacity": "0x23c34600",
+              "data": "0x",
+              "lock": {
+                "args": "0xb2e61ff569acf041b3c2c17724e2379c581eeac3",
+                "code_hash": "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794",
+                "hash_type": "data"
               },
               "type": nil
             }
           ],
-          "version":"0x0",
-          "witnesses":[
+          "version": "0x0",
+          "witnesses": [
             "0x5d0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce801140000003954acece65096bfa81258983ddb83915fc56bd804000000123456780000000000000000"
           ]
         },
-          {
-            "header_deps": [],
-            "cell_deps": [],
-            "outputs_data": [
-              "0x"
-            ],
-            "hash": "0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6bf2",
-            "inputs": [
-              {
-                "previous_output": {
-                  "tx_hash": "0x598315db9c7ba144cca74d2e9122ac9b3a3da1641b2975ae321d91ec34f1c0e3",
-                  "index": "0x2"
-                },
-                "since": "0x0"
-              }
-            ],
-            "outputs": [
-              {
-                "capacity": "0x23c34600",
-                "data": "0x",
-                "lock": {
-                  "args": "0xb2e61ff569acf041b3c2c17724e2379c581eeac3",
-                  "code_hash": "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794",
-                  "hash_type": "data"
-                },
-                "type": nil
-              }
-            ],
-            "version": "0x0",
-            "witnesses": [
-              "0x5d0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce801140000003954acece65096bfa81258983ddb83915fc56bd804000000123456780000000000000000"
-            ]
-          },
-          {
-            "header_deps": [],
-            "cell_deps": [],
-            "outputs_data": [
-              "0x"
-            ],
-            "hash": "0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6b23",
-            "inputs": [
-              {
-                "previous_output": {
-                  "tx_hash": "0x498315db9c7ba144cca74d2e9122ac9b3a3da1641b2975ae321d91ec34f1c0e3",
-                  "index": "0x1"
-                },
-                "since": "0x0"
-              }
-            ],
-            "outputs": [
-              {
-                "capacity": "0x1dcd6500",
-                "data": "0x",
-                "lock": {
-                  "args": "0xb2e61ff569acf041b3c2c17724e2379c581eeac3",
-                  "code_hash": "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794",
-                  "hash_type": "data"
-                },
-                "type": nil
-              }
-            ],
-            "version": "0x0",
-            "witnesses": [
-              "0x"
-            ]
-          }    
-        ],
-      "uncles":[]}    
+        {
+          "header_deps": [],
+          "cell_deps": [],
+          "outputs_data": [
+            "0x"
+          ],
+          "hash": "0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6bf2",
+          "inputs": [
+            {
+              "previous_output": {
+                "tx_hash": "0x598315db9c7ba144cca74d2e9122ac9b3a3da1641b2975ae321d91ec34f1c0e3",
+                "index": "0x2"
+              },
+              "since": "0x0"
+            }
+          ],
+          "outputs": [
+            {
+              "capacity": "0x23c34600",
+              "data": "0x",
+              "lock": {
+                "args": "0xb2e61ff569acf041b3c2c17724e2379c581eeac3",
+                "code_hash": "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794",
+                "hash_type": "data"
+              },
+              "type": nil
+            }
+          ],
+          "version": "0x0",
+          "witnesses": [
+            "0x5d0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce801140000003954acece65096bfa81258983ddb83915fc56bd804000000123456780000000000000000"
+          ]
+        },
+        {
+          "header_deps": [],
+          "cell_deps": [],
+          "outputs_data": [
+            "0x"
+          ],
+          "hash": "0xefb03572314fbb45aba0ef889373d3181117b253664de4dca0934e453b1e6b23",
+          "inputs": [
+            {
+              "previous_output": {
+                "tx_hash": "0x498315db9c7ba144cca74d2e9122ac9b3a3da1641b2975ae321d91ec34f1c0e3",
+                "index": "0x1"
+              },
+              "since": "0x0"
+            }
+          ],
+          "outputs": [
+            {
+              "capacity": "0x1dcd6500",
+              "data": "0x",
+              "lock": {
+                "args": "0xb2e61ff569acf041b3c2c17724e2379c581eeac3",
+                "code_hash": "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794",
+                "hash_type": "data"
+              },
+              "type": nil
+            }
+          ],
+          "version": "0x0",
+          "witnesses": [
+            "0x"
+          ]
+        }
+      ],
+    "uncles": [] }
   CKB::Types::Block.from_h(json_block.deep_symbolize_keys)
 end
 
@@ -389,6 +389,12 @@ module RequestHelpers
     params[:params] ||= {}
     params[:headers] = { "Content-Type": "application/vnd.api+json", "Accept": "application/vnd.api+json" }
     send :get, uri, **params
+  end
+
+  def valid_post(uri, **params)
+    params[:params] ||= {}
+    params[:headers] = { "Content-Type": "application/vnd.api+json", "Accept": "application/vnd.api+json" }
+    post uri, params: params
   end
 end
 


### PR DESCRIPTION
Some address may make url exceed the maximum length supported by browser, cause browser truncate request url or fetch failed.
So I added an POST API for client, so that we can put address params in post body.