### PR TITLE
fixed #74:  Change index type to hash 

### DIFF
--- a/app/models/account_book.rb
+++ b/app/models/account_book.rb
@@ -14,5 +14,5 @@ end
 # Indexes
 #
 #  index_account_books_on_address_id_and_ckb_transaction_id  (address_id,ckb_transaction_id) UNIQUE
-#  index_account_books_on_ckb_transaction_id                 (ckb_transaction_id)
+#  index_account_books_on_ckb_transaction_id                 (ckb_transaction_id) USING hash
 #

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -219,20 +219,19 @@ end
 #  dao_deposit            :decimal(30, )    default(0)
 #  interest               :decimal(30, )    default(0)
 #  block_timestamp        :decimal(30, )
-#  visible                :boolean          default(TRUE)
 #  live_cells_count       :decimal(30, )    default(0)
 #  mined_blocks_count     :integer          default(0)
+#  visible                :boolean          default(TRUE)
 #  average_deposit_time   :decimal(, )
 #  unclaimed_compensation :decimal(30, )
 #  is_depositor           :boolean          default(FALSE)
 #  dao_transactions_count :decimal(30, )    default(0)
 #  lock_script_id         :bigint
 #  balance_occupied       :decimal(30, )    default(0)
-#  address_hash_crc       :bigint
 #
 # Indexes
 #
-#  index_addresses_on_address_hash_crc  (address_hash_crc)
-#  index_addresses_on_is_depositor      (is_depositor) WHERE (is_depositor = true)
-#  index_addresses_on_lock_hash         (lock_hash) UNIQUE
+#  index_addresses_on_address_hash  (address_hash)
+#  index_addresses_on_is_depositor  (is_depositor) WHERE (is_depositor = true)
+#  index_addresses_on_lock_hash     (lock_hash) USING hash
 #

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -47,7 +47,7 @@ class Address < ApplicationRecord
   end
 
   def self.find_or_create_by_address_hash(address_hash, block_timestamp=0)
-    
+
     parsed = CkbUtils.parse_address(address_hash)
     lock_hash = parsed.script.compute_hash
     lock_script = LockScript.find_by(
@@ -57,7 +57,7 @@ class Address < ApplicationRecord
     )
 
     create_with(
-      address_hash: CkbUtils.generate_address(parsed.script), 
+      address_hash: CkbUtils.generate_address(parsed.script),
       block_timestamp: block_timestamp,
       lock_script_id: lock_script&.id,
     ).find_or_create_by lock_hash: lock_hash
@@ -66,37 +66,26 @@ class Address < ApplicationRecord
   def self.find_or_create_address(lock_script, block_timestamp, lock_script_id = nil)
     lock_hash = lock_script.compute_hash
     address_hash = CkbUtils.generate_address(lock_script, CKB::Address::Version::CKB2019)
-    address_hash_crc = CkbUtils.generate_crc32(address_hash)    
     address_hash_2021 = CkbUtils.generate_address(lock_script, CKB::Address::Version::CKB2021)
-    address_hash_crc_2021 = CkbUtils.generate_crc32(address_hash_2021)    
 
-    unless address = Address.find_by(lock_hash: lock_hash)
-      # first try 2019 version style address hash
-      address = Address.find_by(address_hash_crc: address_hash_crc, address_hash: address_hash)
-
-      # then try 2021 version style address hash
-      address ||= Address.find_by(address_hash_crc: address_hash_crc_2021, address_hash: address_hash_2021)
-
-      # either exists, then create new address
-      address ||= Address.new
-
-      # fill missing lock_hash field
-      address.lock_hash ||= lock_hash
+    address = Address.find_by(lock_hash: lock_hash)
+    if address.blank?
+      address = Address.new lock_hash: lock_hash
     end
+
     # force use new version address
     address.address_hash = address_hash_2021
-    address.address_hash_crc = address_hash_crc_2021
     address.block_timestamp ||= block_timestamp
     address.lock_script_id ||= lock_script_id
     if address.balance < 0 || address.balance_occupied < 0 # wrong balance, recalculate balance
-      puts "#{address.address_hash} balance #{address.balance}, #{address.balance_occupied} < 0, resetting"
+      Rails.logger.info "#{address.address_hash} balance #{address.balance}, #{address.balance_occupied} < 0, resetting"
       wrong_balance = address.balance
       address.cal_balance!
-      puts "#{address.address_hash} balance #{address.balance}, #{address.balance_occupied}"
+      Rails.logger.info "#{address.address_hash} balance #{address.balance}, #{address.balance_occupied}"
       Sentry.capture_message(
-        'Reset balance', 
+        'Reset balance',
         extra: {
-          address: address.address_hash, 
+          address: address.address_hash,
           wrong_balance: wrong_balance,
           calced_balance: address.balance,
           calced_occupied_balance: address.balance_occupied

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -140,6 +140,7 @@ end
 #  timestamp                  :decimal(30, )
 #  transactions_root          :binary
 #  proposals_hash             :binary
+#  uncles_count               :integer
 #  extra_hash                 :binary
 #  uncle_block_hashes         :binary
 #  version                    :integer
@@ -147,7 +148,6 @@ end
 #  proposals_count            :integer
 #  cell_consumed              :decimal(30, )
 #  miner_hash                 :binary
-#  miner_message              :string
 #  reward                     :decimal(30, )
 #  total_transaction_fee      :decimal(30, )
 #  ckb_transactions_count     :decimal(30, )    default(0)
@@ -167,18 +167,18 @@ end
 #  nonce                      :decimal(50, )    default(0)
 #  start_number               :decimal(30, )    default(0)
 #  length                     :decimal(30, )    default(0)
-#  uncles_count               :integer
 #  compact_target             :decimal(20, )
 #  live_cell_changes          :integer
 #  block_time                 :decimal(13, )
 #  block_size                 :integer
 #  proposal_reward            :decimal(30, )
 #  commit_reward              :decimal(30, )
+#  miner_message              :string
 #  extension                  :jsonb
 #
 # Indexes
 #
-#  index_blocks_on_block_hash  (block_hash) UNIQUE
+#  index_blocks_on_block_hash  (block_hash) USING hash
 #  index_blocks_on_block_size  (block_size)
 #  index_blocks_on_block_time  (block_time)
 #  index_blocks_on_epoch       (epoch)

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -80,7 +80,7 @@ class Block < ApplicationRecord
   end
 
   def miner_address
-    Address.find_by_address_hash(miner_hash, address_hash_crc: CkbUtils.generate_crc32(miner_hash))
+    Address.find_by_address_hash(miner_hash)
   end
 
   def flush_cache

--- a/app/models/cell_output.rb
+++ b/app/models/cell_output.rb
@@ -248,6 +248,7 @@ end
 #  dao                      :string
 #  lock_script_id           :bigint
 #  type_script_id           :bigint
+#  tx_hash_cell_index       :string
 #
 # Indexes
 #
@@ -260,6 +261,7 @@ end
 #  index_cell_outputs_on_generated_by_id           (generated_by_id)
 #  index_cell_outputs_on_lock_script_id            (lock_script_id)
 #  index_cell_outputs_on_status                    (status)
+#  index_cell_outputs_on_tx_hash_cell_index        (tx_hash_cell_index) USING hash
 #  index_cell_outputs_on_type_script_id            (type_script_id)
 #  index_cell_outputs_on_type_script_id_and_id     (type_script_id,id)
 #

--- a/app/models/cell_output.rb
+++ b/app/models/cell_output.rb
@@ -260,7 +260,6 @@ end
 #  index_cell_outputs_on_generated_by_id           (generated_by_id)
 #  index_cell_outputs_on_lock_script_id            (lock_script_id)
 #  index_cell_outputs_on_status                    (status)
-#  index_cell_outputs_on_tx_hash_and_cell_index    (tx_hash,cell_index)
 #  index_cell_outputs_on_type_script_id            (type_script_id)
 #  index_cell_outputs_on_type_script_id_and_id     (type_script_id,id)
 #

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -914,6 +914,7 @@ module CkbSync
         block_id: local_block.id,
         tx_hash: ckb_transaction["tx_hash"],
         cell_index: cell_index,
+        tx_hash_cell_index: "#{ckb_transaction["tx_hash"]}-#{cell_index}",
         generated_by_id: ckb_transaction["id"],
         cell_type: cell_type,
         block_timestamp: local_block.timestamp,

--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -233,9 +233,9 @@ end
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  is_cellbase           :boolean          default(FALSE)
-#  witnesses             :jsonb
 #  header_deps           :binary
 #  cell_deps             :jsonb
+#  witnesses             :jsonb
 #  live_cell_changes     :integer
 #  capacity_involved     :decimal(30, )
 #  contained_address_ids :bigint           default([]), is an Array
@@ -246,10 +246,9 @@ end
 #
 # Indexes
 #
-#  alter_pk                                                (id,contained_address_ids) USING gin
 #  index_ckb_transactions_on_block_id_and_block_timestamp  (block_id,block_timestamp)
 #  index_ckb_transactions_on_block_timestamp_and_id        (block_timestamp DESC NULLS LAST,id DESC)
-#  index_ckb_transactions_on_contained_address_ids         (contained_address_ids) USING gin
+#  index_ckb_transactions_on_contained_address_ids_and_id  (contained_address_ids,id) USING gin
 #  index_ckb_transactions_on_contained_udt_ids             (contained_udt_ids) USING gin
 #  index_ckb_transactions_on_dao_address_ids               (dao_address_ids) USING gin
 #  index_ckb_transactions_on_is_cellbase                   (is_cellbase)

--- a/app/models/lock_script.rb
+++ b/app/models/lock_script.rb
@@ -106,5 +106,5 @@ end
 #  index_lock_scripts_on_address_id                        (address_id)
 #  index_lock_scripts_on_cell_output_id                    (cell_output_id)
 #  index_lock_scripts_on_code_hash_and_hash_type_and_args  (code_hash,hash_type,args)
-#  index_lock_scripts_on_script_hash                       (script_hash)
+#  index_lock_scripts_on_script_hash                       (script_hash) USING hash
 #

--- a/app/models/pool_transaction_entry.rb
+++ b/app/models/pool_transaction_entry.rb
@@ -72,6 +72,6 @@ end
 #
 # Indexes
 #
-#  index_pool_transaction_entries_on_tx_hash    (tx_hash) UNIQUE
+#  index_pool_transaction_entries_on_tx_hash    (tx_hash) USING hash
 #  index_pool_transaction_entries_on_tx_status  (tx_status)
 #

--- a/app/models/token_collection.rb
+++ b/app/models/token_collection.rb
@@ -114,6 +114,6 @@ end
 # Indexes
 #
 #  index_token_collections_on_cell_id         (cell_id)
-#  index_token_collections_on_sn              (sn) UNIQUE
+#  index_token_collections_on_sn              (sn) USING hash
 #  index_token_collections_on_type_script_id  (type_script_id)
 #

--- a/app/models/type_script.rb
+++ b/app/models/type_script.rb
@@ -51,5 +51,5 @@ end
 #
 #  index_type_scripts_on_cell_output_id                    (cell_output_id)
 #  index_type_scripts_on_code_hash_and_hash_type_and_args  (code_hash,hash_type,args)
-#  index_type_scripts_on_script_hash                       (script_hash)
+#  index_type_scripts_on_script_hash                       (script_hash) USING hash
 #

--- a/app/models/udt.rb
+++ b/app/models/udt.rb
@@ -67,5 +67,5 @@ end
 #
 # Indexes
 #
-#  index_udts_on_type_hash  (type_hash) UNIQUE
+#  index_udts_on_type_hash  (type_hash) USING hash
 #

--- a/db/migrate/20221009072146_change_index_type_for_addresses.rb
+++ b/db/migrate/20221009072146_change_index_type_for_addresses.rb
@@ -2,14 +2,20 @@ class ChangeIndexTypeForAddresses < ActiveRecord::Migration[6.1]
   def self.up
     remove_index :addresses, name: "index_addresses_on_address_hash_crc"
     remove_index :addresses, name: "index_addresses_on_lock_hash"
+
     add_index :addresses, :address_hash
     add_index :addresses, :lock_hash, using: 'hash'
+
+    remove_column :addresses, :address_hash_crc
   end
 
   def self.down
-    remove_index :addresses, name: "index_addresses_on_address_hash"
-    add_index :addresses, :address_hash_crc
+    add_column :addresses, :address_hash_crc, :bigint
+
     remove_index :addresses, name: "index_addresses_on_lock_hash"
+    remove_index :addresses, name: "index_addresses_on_address_hash"
+
     add_index :addresses, :lock_hash
+    add_index :addresses, :address_hash_crc
   end
 end

--- a/db/migrate/20221009072146_change_index_type_for_addresses.rb
+++ b/db/migrate/20221009072146_change_index_type_for_addresses.rb
@@ -1,0 +1,15 @@
+class ChangeIndexTypeForAddresses < ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :addresses, name: "index_addresses_on_address_hash_crc"
+    remove_index :addresses, name: "index_addresses_on_lock_hash"
+    add_index :addresses, :address_hash
+    add_index :addresses, :lock_hash, using: 'hash'
+  end
+
+  def self.down
+    remove_index :addresses, name: "index_addresses_on_address_hash"
+    add_index :addresses, :address_hash_crc
+    remove_index :addresses, name: "index_addresses_on_lock_hash"
+    add_index :addresses, :lock_hash
+  end
+end

--- a/db/migrate/20221009072146_change_index_type_for_addresses.rb
+++ b/db/migrate/20221009072146_change_index_type_for_addresses.rb
@@ -5,13 +5,16 @@ class ChangeIndexTypeForAddresses < ActiveRecord::Migration[6.1]
 
     add_index :addresses, :address_hash
     add_index :addresses, :lock_hash, using: 'hash'
+    execute "alter table public.addresses add constraint unique_lock_hash unique (lock_hash);"
 
     remove_column :addresses, :address_hash_crc
+
   end
 
   def self.down
     add_column :addresses, :address_hash_crc, :bigint
 
+    execute "alter table public.addresses drop constraint unique_lock_hash;"
     remove_index :addresses, name: "index_addresses_on_lock_hash"
     remove_index :addresses, name: "index_addresses_on_address_hash"
 

--- a/db/migrate/20221009073948_change_index_type_for_blocks.rb
+++ b/db/migrate/20221009073948_change_index_type_for_blocks.rb
@@ -1,0 +1,11 @@
+class ChangeIndexTypeForBlocks < ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :blocks, name: "index_blocks_on_block_hash"
+    add_index :blocks, :block_hash, using: 'hash'
+  end
+
+  def self.down
+    remove_index :blocks, name: "index_blocks_on_block_hash"
+    add_index :blocks, :block_hash
+  end
+end

--- a/db/migrate/20221009075753_change_index_type_for_lock_scripts.rb
+++ b/db/migrate/20221009075753_change_index_type_for_lock_scripts.rb
@@ -1,0 +1,11 @@
+class ChangeIndexTypeForLockScripts < ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :lock_scripts, name: "index_lock_scripts_on_script_hash"
+    add_index :lock_scripts, :script_hash, using: 'hash'
+  end
+
+  def self.down
+    remove_index :lock_scripts, name: "index_lock_scripts_on_script_hash"
+    add_index :lock_scripts, :script_hash
+  end
+end

--- a/db/migrate/20221009080035_change_index_type_for_pool_transaction_entries.rb
+++ b/db/migrate/20221009080035_change_index_type_for_pool_transaction_entries.rb
@@ -1,0 +1,11 @@
+class ChangeIndexTypeForPoolTransactionEntries < ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :pool_transaction_entries, name: "index_pool_transaction_entries_on_tx_hash"
+    add_index :pool_transaction_entries, :tx_hash, using: 'hash'
+  end
+
+  def self.down
+    remove_index :pool_transaction_entries, name: "index_pool_transaction_entries_on_tx_hash"
+    add_index :pool_transaction_entries, :tx_hash
+  end
+end

--- a/db/migrate/20221009080035_change_index_type_for_pool_transaction_entries.rb
+++ b/db/migrate/20221009080035_change_index_type_for_pool_transaction_entries.rb
@@ -2,9 +2,11 @@ class ChangeIndexTypeForPoolTransactionEntries < ActiveRecord::Migration[6.1]
   def self.up
     remove_index :pool_transaction_entries, name: "index_pool_transaction_entries_on_tx_hash"
     add_index :pool_transaction_entries, :tx_hash, using: 'hash'
+    execute "alter table public.pool_transaction_entries add constraint unique_tx_hash unique (tx_hash);"
   end
 
   def self.down
+    execute "alter table public.pool_transaction_entries drop constraint unique_tx_hash;"
     remove_index :pool_transaction_entries, name: "index_pool_transaction_entries_on_tx_hash"
     add_index :pool_transaction_entries, :tx_hash
   end

--- a/db/migrate/20221009080306_change_index_type_for_token_collections.rb
+++ b/db/migrate/20221009080306_change_index_type_for_token_collections.rb
@@ -1,0 +1,11 @@
+class ChangeIndexTypeForTokenCollections< ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :token_collections, name: "index_token_collections_on_sn"
+    add_index :token_collections, :sn, using: 'hash'
+  end
+
+  def self.down
+    remove_index :token_collections, name: "index_token_collections_on_sn"
+    add_index :token_collections, :sn
+  end
+end

--- a/db/migrate/20221009080306_change_index_type_for_token_collections.rb
+++ b/db/migrate/20221009080306_change_index_type_for_token_collections.rb
@@ -2,9 +2,11 @@ class ChangeIndexTypeForTokenCollections< ActiveRecord::Migration[6.1]
   def self.up
     remove_index :token_collections, name: "index_token_collections_on_sn"
     add_index :token_collections, :sn, using: 'hash'
+    execute "alter table public.token_collections add constraint unique_sn unique (sn);"
   end
 
   def self.down
+    execute "alter table public.token_collections drop constraint unique_sn;"
     remove_index :token_collections, name: "index_token_collections_on_sn"
     add_index :token_collections, :sn
   end

--- a/db/migrate/20221009080708_change_index_type_for_type_scripts.rb
+++ b/db/migrate/20221009080708_change_index_type_for_type_scripts.rb
@@ -1,0 +1,11 @@
+class ChangeIndexTypeForTypeScripts < ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :type_scripts, name: "index_type_scripts_on_script_hash"
+    add_index :type_scripts, :script_hash, using: 'hash'
+  end
+
+  def self.down
+    remove_index :type_scripts, name: "index_type_scripts_on_script_hash"
+    add_index :type_scripts, :script_hash
+  end
+end

--- a/db/migrate/20221009081118_change_index_type_for_udts.rb
+++ b/db/migrate/20221009081118_change_index_type_for_udts.rb
@@ -1,0 +1,11 @@
+class ChangeIndexTypeForUdts < ActiveRecord::Migration[6.1]
+  def self.up
+    remove_index :udts, name: "index_udts_on_type_hash"
+    add_index :udts, :type_hash, using: 'hash'
+  end
+
+  def self.down
+    remove_index :udts, name: "index_udts_on_type_hash"
+    add_index :udts, :type_hash
+  end
+end

--- a/db/migrate/20221009081118_change_index_type_for_udts.rb
+++ b/db/migrate/20221009081118_change_index_type_for_udts.rb
@@ -2,9 +2,11 @@ class ChangeIndexTypeForUdts < ActiveRecord::Migration[6.1]
   def self.up
     remove_index :udts, name: "index_udts_on_type_hash"
     add_index :udts, :type_hash, using: 'hash'
+    execute "alter table public.udts add constraint unique_type_hash unique (type_hash);"
   end
 
   def self.down
+    execute "alter table public.udts drop constraint unique_type_hash;"
     remove_index :udts, name: "index_udts_on_type_hash"
     add_index :udts, :type_hash
   end

--- a/db/migrate/20221010090239_add_tx_hash_cell_index_to_cell_outputs.rb
+++ b/db/migrate/20221010090239_add_tx_hash_cell_index_to_cell_outputs.rb
@@ -1,0 +1,11 @@
+class AddTxHashCellIndexToCellOutputs < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :cell_outputs, :tx_hash_cell_index, :string
+    add_index :cell_outputs, :tx_hash_cell_index, using: 'hash'
+  end
+
+  def self.down
+    remove_index :cell_outputs, name: "index_cell_outputs_on_tx_hash_cell_index"
+    remove_column :cell_outputs, :tx_hash_cell_index
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -445,7 +445,8 @@ CREATE TABLE public.cell_outputs (
     udt_amount numeric(40,0),
     dao character varying,
     lock_script_id bigint,
-    type_script_id bigint
+    type_script_id bigint,
+    tx_hash_cell_index character varying
 );
 
 
@@ -1969,6 +1970,13 @@ CREATE INDEX index_cell_outputs_on_status ON public.cell_outputs USING btree (st
 
 
 --
+-- Name: index_cell_outputs_on_tx_hash_cell_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_cell_outputs_on_tx_hash_cell_index ON public.cell_outputs USING hash (tx_hash_cell_index);
+
+
+--
 -- Name: index_cell_outputs_on_type_script_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2511,6 +2519,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221009080035'),
 ('20221009080306'),
 ('20221009080708'),
-('20221009081118');
+('20221009081118'),
+('20221010090239');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -65,13 +65,6 @@ $$;
 
 
 --
--- Name: PROCEDURE sync_full_account_book(); Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON PROCEDURE public.sync_full_account_book() IS 'sync contained_address_ids in ckb_transactions to account_books';
-
-
---
 -- Name: synx_tx_to_account_book(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -163,16 +156,15 @@ CREATE TABLE public.addresses (
     dao_deposit numeric(30,0) DEFAULT 0.0,
     interest numeric(30,0) DEFAULT 0.0,
     block_timestamp numeric(30,0),
-    visible boolean DEFAULT true,
     live_cells_count numeric(30,0) DEFAULT 0.0,
     mined_blocks_count integer DEFAULT 0,
+    visible boolean DEFAULT true,
     average_deposit_time numeric,
     unclaimed_compensation numeric(30,0),
     is_depositor boolean DEFAULT false,
     dao_transactions_count numeric(30,0) DEFAULT 0.0,
     lock_script_id bigint,
-    balance_occupied numeric(30,0) DEFAULT 0.0,
-    address_hash_crc bigint
+    balance_occupied numeric(30,0) DEFAULT 0.0
 );
 
 
@@ -219,6 +211,7 @@ CREATE TABLE public.blocks (
     "timestamp" numeric(30,0),
     transactions_root bytea,
     proposals_hash bytea,
+    uncles_count integer,
     extra_hash bytea,
     uncle_block_hashes bytea,
     version integer,
@@ -245,7 +238,6 @@ CREATE TABLE public.blocks (
     nonce numeric(50,0) DEFAULT 0.0,
     start_number numeric(30,0) DEFAULT 0.0,
     length numeric(30,0) DEFAULT 0.0,
-    uncles_count integer,
     compact_target numeric(20,0),
     live_cell_changes integer,
     block_time numeric(13,0),
@@ -491,9 +483,9 @@ CREATE TABLE public.ckb_transactions (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     is_cellbase boolean DEFAULT false,
-    witnesses jsonb,
     header_deps bytea,
     cell_deps jsonb,
+    witnesses jsonb,
     live_cell_changes integer,
     capacity_involved numeric(30,0),
     contained_address_ids bigint[] DEFAULT '{}'::bigint[],
@@ -529,9 +521,9 @@ ALTER SEQUENCE public.ckb_transactions_id_seq OWNED BY public.ckb_transactions.i
 
 CREATE TABLE public.daily_statistics (
     id bigint NOT NULL,
-    transactions_count character varying DEFAULT '0'::character varying,
-    addresses_count character varying DEFAULT '0'::character varying,
-    total_dao_deposit character varying DEFAULT '0.0'::character varying,
+    transactions_count character varying DEFAULT 0,
+    addresses_count character varying DEFAULT 0,
+    total_dao_deposit character varying DEFAULT 0.0,
     block_timestamp numeric(30,0),
     created_at_unixtimestamp integer,
     created_at timestamp(6) without time zone NOT NULL,
@@ -550,8 +542,8 @@ CREATE TABLE public.daily_statistics (
     avg_difficulty character varying DEFAULT '0'::character varying,
     uncle_rate character varying DEFAULT '0'::character varying,
     total_depositors_count character varying DEFAULT '0'::character varying,
-    address_balance_distribution jsonb,
     total_tx_fee numeric(30,0),
+    address_balance_distribution jsonb,
     occupied_capacity numeric(30,0),
     daily_dao_deposit numeric(30,0),
     daily_dao_depositors_count integer,
@@ -712,6 +704,7 @@ CREATE TABLE public.forked_blocks (
     "timestamp" numeric(30,0),
     transactions_root bytea,
     proposals_hash bytea,
+    uncles_count integer,
     extra_hash bytea,
     uncle_block_hashes bytea,
     version integer,
@@ -738,7 +731,6 @@ CREATE TABLE public.forked_blocks (
     nonce numeric(50,0) DEFAULT 0.0,
     start_number numeric(30,0) DEFAULT 0.0,
     length numeric(30,0) DEFAULT 0.0,
-    uncles_count integer,
     compact_target numeric(20,0),
     live_cell_changes integer,
     block_time numeric(13,0),
@@ -1050,40 +1042,6 @@ CREATE SEQUENCE public.token_collections_id_seq
 --
 
 ALTER SEQUENCE public.token_collections_id_seq OWNED BY public.token_collections.id;
-
-
---
--- Name: token_issuers; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.token_issuers (
-    id bigint NOT NULL,
-    name character varying,
-    avatar character varying,
-    description character varying,
-    address_id integer,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: token_issuers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.token_issuers_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: token_issuers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.token_issuers_id_seq OWNED BY public.token_issuers.id;
 
 
 --
@@ -1525,13 +1483,6 @@ ALTER TABLE ONLY public.token_collections ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
--- Name: token_issuers id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.token_issuers ALTER COLUMN id SET DEFAULT nextval('public.token_issuers_id_seq'::regclass);
-
-
---
 -- Name: token_items id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1765,14 +1716,6 @@ ALTER TABLE ONLY public.token_collections
 
 
 --
--- Name: token_issuers token_issuers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.token_issuers
-    ADD CONSTRAINT token_issuers_pkey PRIMARY KEY (id);
-
-
---
 -- Name: token_items token_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1837,13 +1780,6 @@ ALTER TABLE ONLY public.uncle_blocks
 
 
 --
--- Name: alter_pk; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX alter_pk ON public.ckb_transactions USING gin (id, contained_address_ids);
-
-
---
 -- Name: index_account_books_on_address_id_and_ckb_transaction_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1854,14 +1790,14 @@ CREATE UNIQUE INDEX index_account_books_on_address_id_and_ckb_transaction_id ON 
 -- Name: index_account_books_on_ckb_transaction_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_account_books_on_ckb_transaction_id ON public.account_books USING btree (ckb_transaction_id);
+CREATE INDEX index_account_books_on_ckb_transaction_id ON public.account_books USING hash (ckb_transaction_id);
 
 
 --
--- Name: index_addresses_on_address_hash_crc; Type: INDEX; Schema: public; Owner: -
+-- Name: index_addresses_on_address_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_addresses_on_address_hash_crc ON public.addresses USING btree (address_hash_crc);
+CREATE INDEX index_addresses_on_address_hash ON public.addresses USING btree (address_hash);
 
 
 --
@@ -1875,7 +1811,7 @@ CREATE INDEX index_addresses_on_is_depositor ON public.addresses USING btree (is
 -- Name: index_addresses_on_lock_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_addresses_on_lock_hash ON public.addresses USING btree (lock_hash);
+CREATE INDEX index_addresses_on_lock_hash ON public.addresses USING hash (lock_hash);
 
 
 --
@@ -1910,7 +1846,7 @@ CREATE UNIQUE INDEX index_block_time_statistics_on_stat_timestamp ON public.bloc
 -- Name: index_blocks_on_block_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_blocks_on_block_hash ON public.blocks USING btree (block_hash);
+CREATE INDEX index_blocks_on_block_hash ON public.blocks USING hash (block_hash);
 
 
 --
@@ -2033,13 +1969,6 @@ CREATE INDEX index_cell_outputs_on_status ON public.cell_outputs USING btree (st
 
 
 --
--- Name: index_cell_outputs_on_tx_hash_and_cell_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_cell_outputs_on_tx_hash_and_cell_index ON public.cell_outputs USING btree (tx_hash, cell_index);
-
-
---
 -- Name: index_cell_outputs_on_type_script_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2068,10 +1997,10 @@ CREATE INDEX index_ckb_transactions_on_block_timestamp_and_id ON public.ckb_tran
 
 
 --
--- Name: index_ckb_transactions_on_contained_address_ids; Type: INDEX; Schema: public; Owner: -
+-- Name: index_ckb_transactions_on_contained_address_ids_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ckb_transactions_on_contained_address_ids ON public.ckb_transactions USING gin (contained_address_ids);
+CREATE INDEX index_ckb_transactions_on_contained_address_ids_and_id ON public.ckb_transactions USING gin (contained_address_ids, id);
 
 
 --
@@ -2183,7 +2112,7 @@ CREATE INDEX index_lock_scripts_on_code_hash_and_hash_type_and_args ON public.lo
 -- Name: index_lock_scripts_on_script_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_lock_scripts_on_script_hash ON public.lock_scripts USING btree (script_hash);
+CREATE INDEX index_lock_scripts_on_script_hash ON public.lock_scripts USING hash (script_hash);
 
 
 --
@@ -2211,7 +2140,7 @@ CREATE UNIQUE INDEX index_nrc_factory_cells_on_code_hash_and_hash_type_and_args 
 -- Name: index_pool_transaction_entries_on_tx_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pool_transaction_entries_on_tx_hash ON public.pool_transaction_entries USING btree (tx_hash);
+CREATE INDEX index_pool_transaction_entries_on_tx_hash ON public.pool_transaction_entries USING hash (tx_hash);
 
 
 --
@@ -2246,7 +2175,7 @@ CREATE INDEX index_token_collections_on_cell_id ON public.token_collections USIN
 -- Name: index_token_collections_on_sn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_token_collections_on_sn ON public.token_collections USING btree (sn);
+CREATE INDEX index_token_collections_on_sn ON public.token_collections USING hash (sn);
 
 
 --
@@ -2254,13 +2183,6 @@ CREATE UNIQUE INDEX index_token_collections_on_sn ON public.token_collections US
 --
 
 CREATE INDEX index_token_collections_on_type_script_id ON public.token_collections USING btree (type_script_id);
-
-
---
--- Name: index_token_issuers_on_address_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_token_issuers_on_address_id ON public.token_issuers USING btree (address_id);
 
 
 --
@@ -2344,7 +2266,7 @@ CREATE INDEX index_type_scripts_on_code_hash_and_hash_type_and_args ON public.ty
 -- Name: index_type_scripts_on_script_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_type_scripts_on_script_hash ON public.type_scripts USING btree (script_hash);
+CREATE INDEX index_type_scripts_on_script_hash ON public.type_scripts USING hash (script_hash);
 
 
 --
@@ -2372,7 +2294,7 @@ CREATE INDEX index_udt_accounts_on_udt_id ON public.udt_accounts USING btree (ud
 -- Name: index_udts_on_type_hash; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_udts_on_type_hash ON public.udts USING btree (type_hash);
+CREATE INDEX index_udts_on_type_hash ON public.udts USING hash (type_hash);
 
 
 --
@@ -2577,12 +2499,18 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220727000610'),
 ('20220801080617'),
 ('20220803030716'),
-('20220805174502'),
-('20220816171251'),
 ('20220822155712'),
 ('20220830023203'),
 ('20220830163001'),
 ('20220904005610'),
-('20220912154933');
+('20220912154933'),
+('20221009070434'),
+('20221009072146'),
+('20221009073948'),
+('20221009075753'),
+('20221009080035'),
+('20221009080306'),
+('20221009080708'),
+('20221009081118');
 
 

--- a/test/factories/address.rb
+++ b/test/factories/address.rb
@@ -5,8 +5,6 @@ FactoryBot.define do
       CKB::Address.new(script).generate
     end
 
-    address_hash_crc { CkbUtils.generate_crc32(address_hash) }
-
     balance { 0 }
     cell_consumed { 0 }
     ckb_transactions_count { 0 }


### PR DESCRIPTION
To get a better performance, some table's index need to be changed from `btree`(which is postgres default) to `hash`. 

according to this table: https://www.notion.so/4327787f09c44ff5b7c54bc9b388a719?v=7681bfed7e284c0aa026e41ac700ed18 

I changed all the `single column index` from btree to hash.

Please review. thanks