### PR TITLE
fixed #101: Sync rejected messages of historical transactions

### DIFF
--- a/app/controllers/api/v1/ckb_transactions_controller.rb
+++ b/app/controllers/api/v1/ckb_transactions_controller.rb
@@ -54,7 +54,7 @@ module Api
 
         raise Api::V1::Exceptions::CkbTransactionNotFoundError if ckb_transaction.blank?
 
-        if ckb_transaction.class == PoolTransactionEntry && ckb_transaction.tx_status.to_s == "rejected" && ckb_transaction.detailed_message.blank?
+        if ckb_transaction.is_a?(PoolTransactionEntry) && ckb_transaction.tx_status.to_s == "rejected" && ckb_transaction.detailed_message.blank?
           ckb_transaction.update_detailed_message_for_rejected_transaction
         end
 

--- a/app/controllers/api/v1/ckb_transactions_controller.rb
+++ b/app/controllers/api/v1/ckb_transactions_controller.rb
@@ -42,7 +42,7 @@ module Api
           end
         ckb_transactions = ckb_transactions.select(:id, :tx_hash, :block_id, :block_number, :block_timestamp, :is_cellbase, :updated_at)
         json = Rails.cache.realize(ckb_transactions.cache_key, version: ckb_transactions.cache_version, race_condition_ttl: 3.seconds) do
-          
+
           options = FastJsonapi::PaginationMetaGenerator.new(request: request, records: ckb_transactions, page: @page, page_size: @page_size, records_counter: records_counter).call
           CkbTransactionsSerializer.new(ckb_transactions, options.merge(params: { previews: true, address: @address })).serialized_json
         end
@@ -54,10 +54,15 @@ module Api
 
         raise Api::V1::Exceptions::CkbTransactionNotFoundError if ckb_transaction.blank?
 
+        if ckb_transaction.class == PoolTransactionEntry && ckb_transaction.tx_status.to_s == "rejected" && ckb_transaction.detailed_message.blank?
+          ckb_transaction.update_detailed_message_for_rejected_transaction
+        end
+
         render json: CkbTransactionSerializer.new(ckb_transaction)
       end
 
       private
+
 
       def from_home_page?
         params[:page].blank? || params[:page_size].blank?

--- a/app/models/pool_transaction_entry.rb
+++ b/app/models/pool_transaction_entry.rb
@@ -44,31 +44,41 @@ class PoolTransactionEntry < ApplicationRecord
       witnesses: Array.wrap(witnesses)
     }
   end
+
+  def update_detailed_message_for_rejected_transaction
+
+    response_string = CkbSync::Api.instance.directly_single_call_rpc method: 'get_transaction', params: [tx_hash]
+    reason = response_string['result']['tx_status']
+    self.update detailed_message: response_string['result']['tx_status']['reason']
+    return self
+  end
+
 end
 
 # == Schema Information
 #
 # Table name: pool_transaction_entries
 #
-#  id              :bigint           not null, primary key
-#  cell_deps       :jsonb
-#  tx_hash         :binary
-#  header_deps     :jsonb
-#  inputs          :jsonb
-#  outputs         :jsonb
-#  outputs_data    :jsonb
-#  version         :integer
-#  witnesses       :jsonb
-#  transaction_fee :decimal(30, )
-#  block_number    :decimal(30, )
-#  block_timestamp :decimal(30, )
-#  cycles          :decimal(30, )
-#  tx_size         :decimal(30, )
-#  display_inputs  :jsonb
-#  display_outputs :jsonb
-#  tx_status       :integer          default("pending")
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id               :bigint           not null, primary key
+#  cell_deps        :jsonb
+#  tx_hash          :binary
+#  header_deps      :jsonb
+#  inputs           :jsonb
+#  outputs          :jsonb
+#  outputs_data     :jsonb
+#  version          :integer
+#  witnesses        :jsonb
+#  transaction_fee  :decimal(30, )
+#  block_number     :decimal(30, )
+#  block_timestamp  :decimal(30, )
+#  cycles           :decimal(30, )
+#  tx_size          :decimal(30, )
+#  display_inputs   :jsonb
+#  display_outputs  :jsonb
+#  tx_status        :integer          default("pending")
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  detailed_message :text
 #
 # Indexes
 #

--- a/test/models/pool_transaction_entry_test.rb
+++ b/test/models/pool_transaction_entry_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class PoolTransactionEntryTest < ActiveSupport::TestCase
+
+  setup do
+    CkbSync::Api.any_instance.stubs(:generate_json_rpc_id).returns(1)
+  end
+
   test "is_cellbase should always be false" do
     tx = create(:pool_transaction_entry)
     assert_equal false, tx.is_cellbase
@@ -14,6 +19,19 @@ class PoolTransactionEntryTest < ActiveSupport::TestCase
     tx = create(:pool_transaction_entry)
     json = tx.to_raw
     assert_equal %w(hash header_deps cell_deps inputs outputs outputs_data version witnesses).sort, json.keys.map(&:to_s).sort
+  end
+
+  test "should update_detailed_message_for_rejected_transaction when detailed_message is nil" do
+
+    rejected_tx_id = '0xed2049c21ffccfcd26281d60f8f77ff117adb9df9d3f8cbe5fe86e893c66d359'
+    tx = create :pool_transaction_entry, tx_status: :rejected, tx_hash: rejected_tx_id
+
+
+    VCR.use_cassette('get_rejected_transaction') do
+      tx.update_detailed_message_for_rejected_transaction
+    end
+
+    assert tx.detailed_message.include?("Resolve failed Dead")
   end
 
 end


### PR DESCRIPTION
update strategy: when user visit a "rejected" transaction which has `no detailed_message`, the backend will update its detailed_message.

So there is no need to run a specific method in `rails console`.

please review