### PR TITLE
Lazy update bytes size for blocks and transactions

### DIFF
--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -58,6 +58,7 @@ class BlockSerializer
     (object.received_tx_fee + object.reward).to_s
   end
   attribute :size do |object|
+    UpdateBlockSizeWorker.perform_async object.id if object.block_size.blank?
     object.block_size
-  end  
+  end
 end

--- a/app/serializers/ckb_transaction_serializer.rb
+++ b/app/serializers/ckb_transaction_serializer.rb
@@ -4,7 +4,6 @@
 class CkbTransactionSerializer
   include FastJsonapi::ObjectSerializer
 
-
   # for the tx_status,
   # CkbTransaction will always be "commited"
   # PoolTransactionEntry will give: 0, 1, 2, 3
@@ -13,8 +12,6 @@ class CkbTransactionSerializer
   attribute :detailed_message do |object|
     if object.tx_status.to_s == "rejected"
       object.detailed_message
-    else
-      nil
     end
   end
 
@@ -57,12 +54,10 @@ class CkbTransactionSerializer
       else
         object.display_outputs(previews: true)
       end
+    elsif object.display_inputs_info.present?
+      object.display_outputs_info
     else
-      if object.display_inputs_info.present?
-        object.display_outputs_info
-      else
-        object.display_outputs
-      end
+      object.display_outputs
     end
   end
 
@@ -71,12 +66,13 @@ class CkbTransactionSerializer
       # if object.tx_display_info.present?
       #   object.tx_display_info.income[params[:address].address_hash]
       # else
-        object.income(params[:address])
+      object.income(params[:address])
       # end
     end
   end
 
   attribute :bytes do |object|
+    UpdateTxBytesWorker.perform_async object.id if object.bytes.blank?
     object.bytes
   end
 end

--- a/app/workers/update_block_size_worker.rb
+++ b/app/workers/update_block_size_worker.rb
@@ -1,0 +1,12 @@
+class UpdateBlockSizeWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "low"
+
+  def perform(block_id)
+    block = Block.find_by(id: block_id)
+    return if block.blank?
+
+    node_block = CkbSync::Api.instance.get_block_by_number(block.number)
+    block.update(block_size: node_block.serialized_size_without_uncle_proposals)
+  end
+end

--- a/app/workers/update_tx_bytes_worker.rb
+++ b/app/workers/update_tx_bytes_worker.rb
@@ -1,0 +1,11 @@
+class UpdateTxBytesWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "low"
+
+  def perform(tx_id)
+    tx = CkbTransaction.find tx_id
+    res = CkbSync::Api.instance.directly_single_call_rpc(method: :get_transaction, params: [tx.tx_hash, "0x0"])
+    tx.bytes = (res["result"]["transaction"].size - 2) / 2
+    tx.save
+  end
+end


### PR DESCRIPTION
For those legacy block & transaction records without bytes size, we issue backgroud job to fill these columns.