### PR TITLE
Retry worker if block record is not present.

### DIFF
--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -58,7 +58,7 @@ class BlockSerializer
     (object.received_tx_fee + object.reward).to_s
   end
   attribute :size do |object|
-    UpdateBlockSizeWorker.perform_async object.id if object.block_size.blank?
+    UpdateBlockSizeWorker.perform_async object.id if object.block_size.blank? or object.block_size == 0
     object.block_size
   end
 end

--- a/app/workers/generate_statistics_data_worker.rb
+++ b/app/workers/generate_statistics_data_worker.rb
@@ -3,7 +3,10 @@ class GenerateStatisticsDataWorker
 
   def perform(block_id)
     block = Block.find_by(id: block_id)
-    return if block.blank?
+    if block.blank?
+      # maybe the block record has not been persisted, so retry later
+      return GenerateStatisticsDataWorker.perform_in(30.seconds, block_id)
+    end
 
     node_block = CkbSync::Api.instance.get_block_by_number(block.number)
     block.update(block_size: node_block.serialized_size_without_uncle_proposals)


### PR DESCRIPTION
The block processor may invoke `GenerateStatisticsDataWorker` asynchronously in background, but due to transaction, the background worker may not be able to see the current block record.
So here we try to restart the job later when cannot find the block record