### PR TITLE
check CKB_NODE_MODE when app starts, and raise error if not found

### DIFF
--- a/config/initializers/config_check.rb
+++ b/config/initializers/config_check.rb
@@ -74,4 +74,4 @@ def check_environments
   end
 end
 
-check_environments() if Rails.env == 'production'
+check_environments() if Rails.env.production?


### PR DESCRIPTION
when web app starts, it will check ENV['CKB_NET_MODE'] and raise error if not found. 

```
environment: CKB_NET_MODE not found, please check '.env' and restart. (RuntimeError)
```