### PR TITLE
fix error in block syncer: some cell does not always have lock/type script 

### DIFF
--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -660,6 +660,7 @@ module CkbSync
         lock_script_ids = LockScript.insert_all!(lock_scripts_attributes)
         lock_script_ids.each do | lock_script_id|
           lock_script = LockScript.where('id = ?', lock_script_id['id']).first
+          next if lock_script.blank?
           contract_id = 0
           Contract.all.each {|contract|
             if contract.code_hash == lock_script.code_hash
@@ -680,6 +681,7 @@ module CkbSync
         type_script_ids = TypeScript.insert_all!(type_scripts_attributes)
         type_script_ids.each do |type_script_id|
           type_script = LockScript.where('id = ?', type_script_id['id']).first
+          next if type_script.blank?
           contract_id = 0
           Contract.all.each {|contract|
             if contract.code_hash == type_script.code_hash


### PR DESCRIPTION
related issue : https://github.com/Magickbase/ckb-explorer-public-issues/issues/188

![image](https://user-images.githubusercontent.com/105087155/217978703-40e0b8a2-09fc-4730-a613-28a0be48af18.png)
