### PR TITLE
create a patch for pending transactions fee rate api, 03-16

### DIFF
--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -5,7 +5,8 @@ module Api::V2
     def transaction_fees
 
       transaction_fee_rates = Rails.cache.fetch("transaction_fees", expires_in: 10.seconds) do
-        CkbTransaction.select(:id, :created_at, :transaction_fee, :bytes, :confirmation_time).where('bytes > 0').order('id desc').limit(10000)
+        CkbTransaction.select(:id, :created_at, :transaction_fee, :bytes, :confirmation_time)
+          .where('bytes > 0 and transaction_fee > 0').order('id desc').limit(10000)
       end
 
       pending_transaction_fee_rates = PoolTransactionEntry.select(:id, :transaction_fee, :bytes, :tx_hash).pool_transaction_pending

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -28,7 +28,7 @@ module Api::V2
         pending_transaction_fee_rates: pending_transaction_fee_rates.map { |tx|
           tx_bytes = tx.bytes
           if tx.bytes.blank? || tx.bytes == 0
-            Rails.logger.info "== tx: #{tx.tx_hash, tx.id}"
+            Rails.logger.info "== tx: #{tx.tx_hash}, #{tx.id}"
             begin
               tx_bytes = CkbSync::Api.instance.get_transaction(tx.tx_hash).transaction.serialized_size_in_block
             rescue Exception => e

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -46,7 +46,7 @@ module Api::V2
         pending_transaction_fee_rates: pending_transaction_fee_rates.map { |tx|
           {
             id: tx.id,
-            fee_rate: (tx.transaction_fee.to_f / tx_bytes),
+            fee_rate: (tx.transaction_fee.to_f / tx.bytes),
           }
         },
         last_n_days_transaction_fee_rates: last_n_days_transaction_fee_rates.map { |day_fee_rate|

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -31,7 +31,7 @@ module Api::V2
             Rails.logger.info "== tx: #{tx.tx_hash, tx.id}"
             begin
               tx_bytes = CkbSync::Api.instance.get_transaction(tx.tx_hash).transaction.serialized_size_in_block
-            rescue
+            rescue Exception => e
               Rails.logger.error "== tx not found"
               tx_bytes = 1
             end

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -22,7 +22,7 @@ module Api::V2
           {
             id: tx.id,
             timestamp: tx.created_at.to_i,
-            fee_rate: (tx.transaction_fee / tx.bytes),
+            fee_rate: (tx.transaction_fee.to_f / tx.bytes),
             confirmation_time: tx.confirmation_time
           }
         },
@@ -40,7 +40,7 @@ module Api::V2
           end
           {
             id: tx.id,
-            fee_rate: (tx.transaction_fee / tx_bytes),
+            fee_rate: (tx.transaction_fee.to_f / tx_bytes),
           }
         },
         last_n_days_transaction_fee_rates: last_n_days_transaction_fee_rates.map { |day_fee_rate|

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -28,7 +28,13 @@ module Api::V2
         pending_transaction_fee_rates: pending_transaction_fee_rates.map { |tx|
           tx_bytes = tx.bytes
           if tx.bytes.blank? || tx.bytes == 0
-            tx_bytes = CkbSync::Api.instance.get_transaction(tx.tx_hash).transaction.serialized_size_in_block
+            Rails.logger.info "== tx: #{tx.tx_hash, tx.id}"
+            begin
+              tx_bytes = CkbSync::Api.instance.get_transaction(tx.tx_hash).transaction.serialized_size_in_block
+            rescue
+              Rails.logger.error "== tx not found"
+              tx_bytes = 1
+            end
             tx.update bytes: tx_bytes
           end
           {


### PR DESCRIPTION
improved the code , based on #1193 
1. only select pending tx which bytes is not 0, which transaction_fee > 0
2. rescue the exception when tx is dropped and not found .