### PR TITLE
Optimize sql of last n days' fee rate

### DIFF
--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -173,22 +173,14 @@ class CkbTransaction < ApplicationRecord
     end
   end
 
-  def self.last_n_days_transaction_fee_rates last_n_day
-    dates = (0..last_n_day).map { |i| i.days.ago.strftime("%Y-%m-%d") }
-    return dates.map { |date|
-      current_date = DateTime.strptime(date, '%Y-%m-%d')
-      fee_rate = Rails.cache.fetch("transaction_fee_rates_on_#{current_date}", expires_in: 10.minutes) do
-        ckb_transactions = CkbTransaction.select(:id, :created_at, :transaction_fee, :bytes)
-          .where('bytes > 0 and transaction_fee > 0 and created_at > ? and created_at < ?', current_date.beginning_of_day, current_date.end_of_day)
-        total_fee_rates = ckb_transactions.map{ |tx| tx.transaction_fee.to_f / tx.bytes }
-        total_fee_rates.sum(0.0) / ckb_transactions.size
-      end
-
-      {
-        date: date,
-        fee_rate: fee_rate
-      }
-    }
+  def self.last_n_days_transaction_fee_rates(last_n_day)
+    CkbTransaction.
+      where("bytes > 0 and transaction_fee > 0").
+      where("block_timestamp >= ?", last_n_day.days.ago.to_i * 1000).
+      group("(block_timestamp / 86400000)::integer").
+      pluck(Arel.sql("(block_timestamp / 86400000)::integer * 86400 as date"),
+            Arel.sql("sum(transaction_fee / bytes) / count(*) as fee_rate")).
+      map { |date, fee_rate| { date: Time.at(date), fee_rate: fee_rate } }
   end
 
   private

--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -178,9 +178,9 @@ class CkbTransaction < ApplicationRecord
       where("bytes > 0 and transaction_fee > 0").
       where("block_timestamp >= ?", last_n_day.days.ago.to_i * 1000).
       group("(block_timestamp / 86400000)::integer").
-      pluck(Arel.sql("(block_timestamp / 86400000)::integer * 86400 as date"),
+      pluck(Arel.sql("(block_timestamp / 86400000)::integer as date"),
             Arel.sql("sum(transaction_fee / bytes) / count(*) as fee_rate")).
-      map { |date, fee_rate| { date: Time.at(date), fee_rate: fee_rate } }
+      map { |date, fee_rate| { date: Time.at(date * 86400).utc.strftime("%Y-%m-%d"), fee_rate: fee_rate } }
   end
 
   private

--- a/test/controllers/api/v2/statistics_controller_test.rb
+++ b/test/controllers/api/v2/statistics_controller_test.rb
@@ -8,7 +8,7 @@ module Api
         confirmation_time = 10
         tx_created_at = pending_tx_create_at + confirmation_time
 
-        block = create(:block)
+        block = create(:block, timestamp: Faker::Time.between(from: 2.days.ago, to: Date.today).to_i * 1000)
         tx_hash1 = "0x497277029e6335c6d5f916574dc4475ee229f3c1cce3658e7dad017a8ed580d4"
         tx_hash2 = "0xe9772bae467924e0feee85e9b7087993d38713bd8c19c954c4b68da69b4f4644"
         create :ckb_transaction, created_at: Time.at(tx_created_at), transaction_fee: 30000, bytes: 20, confirmation_time: confirmation_time, block: block, tx_hash: tx_hash1

--- a/test/controllers/api/v2/statistics_controller_test.rb
+++ b/test/controllers/api/v2/statistics_controller_test.rb
@@ -4,7 +4,6 @@ module Api
   module V2
     class StatisticsControllerTest < ActionDispatch::IntegrationTest
       setup do
-
         pending_tx_create_at = Time.now.to_i
         confirmation_time = 10
         tx_created_at = pending_tx_create_at + confirmation_time
@@ -22,9 +21,9 @@ module Api
         VCR.use_cassette("get transaction_fees, for committed tx") do
           get transaction_fees_api_v2_statistics_url, headers: { "Content-Type": "application/vnd.api+json", "Accept": "application/json" }
           data = JSON.parse(response.body)
-          assert_equal PoolTransactionEntry.all.size, data['transaction_fee_rates'].size
-          assert data['transaction_fee_rates'].first['fee_rate'] > 0
-          assert data['transaction_fee_rates'].first['confirmation_time'] > 0
+          assert_equal PoolTransactionEntry.all.size, data["transaction_fee_rates"].size
+          assert data["transaction_fee_rates"].first["fee_rate"] > 0
+          assert data["transaction_fee_rates"].first["confirmation_time"] > 0
           assert_response :success
         end
       end
@@ -33,8 +32,8 @@ module Api
         VCR.use_cassette("get transaction_fees, for pending tx") do
           get transaction_fees_api_v2_statistics_url, headers: { "Content-Type": "application/vnd.api+json", "Accept": "application/json" }
           data = JSON.parse(response.body)
-          assert_equal PoolTransactionEntry.all.size, data['transaction_fee_rates'].size
-          assert data['pending_transaction_fee_rates'].first['fee_rate'] > 0
+          assert_equal PoolTransactionEntry.all.size, data["transaction_fee_rates"].size
+          assert data["pending_transaction_fee_rates"].first["fee_rate"] > 0
 
           assert_response :success
         end
@@ -52,10 +51,11 @@ module Api
 
           get transaction_fees_api_v2_statistics_url, headers: { "Content-Type": "application/vnd.api+json", "Accept": "application/json" }
           data = JSON.parse(response.body)
-          assert_equal 7, data['last_n_days_transaction_fee_rates'].size
-          assert_equal "#{Time.now.strftime("%Y-%m-%d")}", data['last_n_days_transaction_fee_rates'].first['date']
-          assert_equal 3.0, data['last_n_days_transaction_fee_rates'].first['fee_rate']
 
+          assert_equal 1, data["last_n_days_transaction_fee_rates"].size
+          # compare with the block timestamp
+          assert_equal "#{Time.at(block.timestamp / 1000).utc.strftime('%Y-%m-%d')}", data["last_n_days_transaction_fee_rates"].first["date"]
+          assert_equal "3.0", data["last_n_days_transaction_fee_rates"].first["fee_rate"]
           assert_response :success
         end
       end

--- a/test/factories/block.rb
+++ b/test/factories/block.rb
@@ -5,7 +5,8 @@ FactoryBot.define do
     number { 10 }
     parent_hash { "0xcba2d1a70602a1def80efbd59629c37a9d6c36f9de7a8ed6d1ca4f76389365e1" }
     nonce { 1757392074788233522 }
-    timestamp { Faker::Time.between(from: 2.days.ago, to: Date.today).to_i * 1000 }
+    # FIXME: the timestamp in blocks table is in milliseconds but here is in seconds
+    timestamp { Faker::Time.between(from: 2.days.ago, to: Date.today).to_i }
     transactions_root { "0xe08894ef0ed80481448f7a584438a76b6bdbea178c02b4c3b40863d75c5aed3c" }
     proposals_hash { "0x0000000000000000000000000000000000000000000000000000000000000000" }
     uncles_count { 1 }

--- a/test/factories/block.rb
+++ b/test/factories/block.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     number { 10 }
     parent_hash { "0xcba2d1a70602a1def80efbd59629c37a9d6c36f9de7a8ed6d1ca4f76389365e1" }
     nonce { 1757392074788233522 }
-    timestamp { Faker::Time.between(from: 2.days.ago, to: Date.today).to_i }
+    timestamp { Faker::Time.between(from: 2.days.ago, to: Date.today).to_i * 1000 }
     transactions_root { "0xe08894ef0ed80481448f7a584438a76b6bdbea178c02b4c3b40863d75c5aed3c" }
     proposals_hash { "0x0000000000000000000000000000000000000000000000000000000000000000" }
     uncles_count { 1 }


### PR DESCRIPTION
The original algorithm is to fetch all ckb transactions from database and calculate day by bay in Rails layer.
I move the aggregation into database layer.