### PR TITLE
feat: add cell_type index to cell_outputs table

### DIFF
--- a/app/models/cell_output.rb
+++ b/app/models/cell_output.rb
@@ -345,6 +345,7 @@ end
 #  index_cell_outputs_on_address_id_and_status     (address_id,status)
 #  index_cell_outputs_on_block_id                  (block_id)
 #  index_cell_outputs_on_block_timestamp           (block_timestamp)
+#  index_cell_outputs_on_cell_type                 (cell_type)
 #  index_cell_outputs_on_ckb_transaction_id        (ckb_transaction_id)
 #  index_cell_outputs_on_consumed_block_timestamp  (consumed_block_timestamp)
 #  index_cell_outputs_on_consumed_by_id            (consumed_by_id)

--- a/db/migrate/20230425114436_add_cell_type_index_to_cell_output.rb
+++ b/db/migrate/20230425114436_add_cell_type_index_to_cell_output.rb
@@ -1,0 +1,5 @@
+class AddCellTypeIndexToCellOutput < ActiveRecord::Migration[7.0]
+  def change
+    add_index :cell_outputs, :cell_type
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3341,6 +3341,13 @@ CREATE INDEX index_cell_outputs_on_block_timestamp ON public.cell_outputs USING 
 
 
 --
+-- Name: index_cell_outputs_on_cell_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_cell_outputs_on_cell_type ON public.cell_outputs USING btree (cell_type);
+
+
+--
 -- Name: index_cell_outputs_on_ckb_transaction_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4411,6 +4418,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230406011556'),
 ('20230412070853'),
 ('20230415042814'),
-('20230415150143');
+('20230415150143'),
+('20230425114436');
 
 


### PR DESCRIPTION
Before cell_outputs table only have status index.So when we run `CellOutput.nervos_dao_deposit.live` code is very slow.
After add cell_type index, became faster.
- - -
Run this migration may need 2 minutes.