### PR TITLE
fixed bug: /api/v2/statistics/transaction_fees , missing scope: tx_committed

### DIFF
--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -4,9 +4,12 @@ module Api::V2
 
     def transaction_fees
       expires_in 15.seconds, public: true
-      transaction_fee_rates =
-        CkbTransaction.
-          where("bytes > 0 and transaction_fee > 0").order("id desc").limit(10000).pluck(:id, :created_at, :transaction_fee, :bytes, :confirmation_time)
+      transaction_fee_rates = CkbTransaction
+        .tx_committed
+        .where("bytes > 0 and transaction_fee > 0")
+        .order("id desc")
+        .limit(10000)
+        .pluck(:id, :created_at, :transaction_fee, :bytes, :confirmation_time)
 
       # select from database
       pending_transaction_fee_rates = PoolTransactionEntry.pool_transaction_pending.


### PR DESCRIPTION
in api: https://testnet-api.explorer.nervos.org/api/v2/statistics/transaction_fees
, in the response , segment `transaction_fee_rates` is incorrect.

expected: return `committed` ckb_transactions
current: return `all` ckb_transactions.

so this caused the incorrect fee rate, e.g. 

![image](https://user-images.githubusercontent.com/105087155/235114826-d6bf4835-45bc-4669-bf8f-c06ce6c465c0.png)
