### PR TITLE
DailyStatistics bug fix

### DIFF
--- a/app/services/charts/daily_statistic_generator.rb
+++ b/app/services/charts/daily_statistic_generator.rb
@@ -43,7 +43,7 @@ module Charts
     end
 
     def transactions_in_current_period
-      @transactions_in_current_period ||= CkbTransaction.created_between(started_at, ended_at)
+      @transactions_in_current_period ||= CkbTransaction.tx_committed.created_between(started_at, ended_at)
     end
 
     def cell_generated_in_current_period

--- a/app/workers/charts/daily_statistic.rb
+++ b/app/workers/charts/daily_statistic.rb
@@ -5,10 +5,15 @@ module Charts
 
     # iterate from the creation timestamp of last daily statistic record to now day by day
     # and generate daily statistic record for each day
-    def perform(datetime = nil)
+    def perform(datetime = nil, start_time = nil)
       datetime ||= 1.day.ago.beginning_of_day
-      last_record = ::DailyStatistic.order(created_at_unixtimestamp: :desc).first
-      start_time = Time.zone.at(last_record ? last_record.created_at_unixtimestamp : (Block.find_by(number: 0).timestamp / 1000) - 86400)
+
+      unless start_time
+        last_record = ::DailyStatistic.order(created_at_unixtimestamp: :desc).first
+        start_time = Time.zone.at(last_record ? last_record.created_at_unixtimestamp : (Block.find_by(number: 0).timestamp / 1000) - 86400)
+      end
+
+      start_time = start_time.beginning_of_day
 
       while start_time < datetime
         start_time += 1.day

--- a/app/workers/charts/daily_statistic.rb
+++ b/app/workers/charts/daily_statistic.rb
@@ -13,7 +13,7 @@ module Charts
         start_time = Time.zone.at(last_record ? last_record.created_at_unixtimestamp : (Block.find_by(number: 0).timestamp / 1000) - 86400)
       end
 
-      start_time = start_time.beginning_of_day
+      start_time = start_time.in_time_zone.beginning_of_day
 
       while start_time < datetime
         start_time += 1.day

--- a/app/workers/charts/daily_statistic.rb
+++ b/app/workers/charts/daily_statistic.rb
@@ -8,7 +8,8 @@ module Charts
     def perform(datetime = nil)
       datetime ||= 1.day.ago.beginning_of_day
       last_record = ::DailyStatistic.order(created_at_unixtimestamp: :desc).first
-      start_time = Time.zone.at(last_record ? last_record.created_at_unixtimestamp : Block.find_by(number: 0).timestamp / 1000)
+      start_time = Time.zone.at(last_record ? last_record.created_at_unixtimestamp : (Block.find_by(number: 0).timestamp / 1000) - 86400)
+
       while start_time < datetime
         start_time += 1.day
         Charts::DailyStatisticGenerator.new(start_time).call

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,0 @@
-set :domain, ""
-set :deploy_to, ""
-set :repository, ""
-set :branch, ""
-set :user, ""

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,0 @@
-set :domain, "47.97.171.140"
-set :deploy_to, "/home/deploy/ckb-explorer"
-set :branch, "develop"
-set :user, "root"
-set :rvm_use_path, "/usr/share/rvm/scripts/rvm"

--- a/db/migrate/20230510235147_add_unique_index_to_daily_statistic_timestamp.rb
+++ b/db/migrate/20230510235147_add_unique_index_to_daily_statistic_timestamp.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToDailyStatisticTimestamp < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :daily_statistics, :created_at_unixtimestamp
+    add_index :daily_statistics, :created_at_unixtimestamp, unique: true
+  end
+end


### PR DESCRIPTION
1. restrict transaction to committed status for counting
2. allow we set a start time when generating daily statistics 
3. make `created_at_unixtimestamp` field unique in daily statistics