### PR TITLE
Add namespace for Rails cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "ckb-sdk-ruby", github: "ShiningRay/ckb-sdk-ruby", require: "ckb", branch: "
 # Redis
 gem "hiredis" # , "~> 0.6.3"
 gem "redis" # , "~> 4.2.0"
-
+gem "hiredis-client"
 gem "digest-crc"
 
 # Backgroud Jobs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,8 @@ GEM
       activesupport (>= 5.0)
     hashdiff (1.0.1)
     hiredis (0.6.3)
+    hiredis-client (0.14.1)
+      redis-client (= 0.14.1)
     http (5.1.0)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -341,7 +343,7 @@ GEM
       mini_portile2 (~> 2.8)
       pkg-config (~> 1.5)
       rubyzip (~> 2.3)
-    redis (5.0.5)
+    redis (5.0.6)
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
@@ -474,6 +476,7 @@ DEPENDENCIES
   fast_jsonapi
   fast_page
   hiredis
+  hiredis-client
   http
   jbuilder
   kaminari

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,12 @@ Rails.application.configure do
   # Run rails dev:cache to toggle caching.
 
   if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.cache_store = :redis_cache_store
+    config.cache_store =
+      :redis_cache_store, {
+        url: ENV["REDIS_URL"],
+        driver: :hiredis,
+        namespace: ENV["CACHE_NAMESPACE"]
+      }
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,11 +47,16 @@ Rails.application.configure do
   config.log_level = ENV.fetch("LOG_LEVEL") { "info" }
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-  config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], password: ENV["REDIS_PASSWORD"] }
+  config.cache_store =
+    :redis_cache_store, {
+      url: ENV["REDIS_URL"],
+      driver: :hiredis,
+      namespace: ENV["CACHE_NAMESPACE"]
+    }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Add a namespace for caches, in order to clear only rails cache, not affecting sidekiq queues
use hiredis driver for better performance