### PR TITLE
Upgrade legacy fields to correct name

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -21,15 +21,10 @@ class Address < ApplicationRecord
   attr_accessor :query_address
 
   def custom_ckb_transactions
-    # CkbTransaction.where("contained_address_ids @> array[?]::bigint[]", [id]) # .optimizer_hints("indexscan(ckb_transactions index_ckb_transactions_on_contained_address_ids)")
     ckb_transactions
   end
 
   has_and_belongs_to_many :ckb_dao_transactions, class_name: "CkbTransaction", join_table: "address_dao_transactions"
-
-  # def ckb_dao_transactions
-  #   CkbTransaction.where("dao_address_ids @> array[?]::bigint[]", [id]) # .optimizer_hints("indexscan(ckb_transactions index_ckb_transactions_on_dao_address_ids)")
-  # end
 
   def ckb_udt_transactions(udt)
     udt = Udt.find_by_id(udt) unless udt.is_a?(Udt)

--- a/app/models/ckb_sync/node_data_processor.rb
+++ b/app/models/ckb_sync/node_data_processor.rb
@@ -744,8 +744,15 @@ udt_infos, address_ids, tags, udt_ids, dao_address_ids, udt_address_ids
         tx[:contained_udt_ids] = (tx[:contained_udt_ids] << consumed_tx.contained_udt_ids).flatten.uniq
       else
         updated_ckb_transactions << {
-          id: consumed_tx.id, dao_address_ids: consumed_tx.dao_address_ids.uniq,
-          udt_address_ids: consumed_tx.udt_address_ids.uniq, contained_udt_ids: consumed_tx.contained_udt_ids.uniq, contained_address_ids: consumed_tx.contained_address_ids.uniq, tags: consumed_tx.tags.uniq, created_at: consumed_tx.created_at, updated_at: Time.current }
+          id: consumed_tx.id,
+          contained_dao_address_ids: consumed_tx.dao_address_ids.uniq,
+          contained_udt_address_ids: consumed_tx.udt_address_ids.uniq,
+          contained_udt_ids: consumed_tx.contained_udt_ids.uniq,
+          contained_address_ids: consumed_tx.contained_address_ids.uniq,
+          tags: consumed_tx.tags.uniq,
+          created_at: consumed_tx.created_at,
+          updated_at: Time.current
+        }
       end
     end
 

--- a/app/models/ckb_transaction.rb
+++ b/app/models/ckb_transaction.rb
@@ -32,32 +32,6 @@ class CkbTransaction < ApplicationRecord
   has_and_belongs_to_many :contained_dao_addresses, class_name: "Address", join_table: "address_dao_transactions"
   has_and_belongs_to_many :contained_udt_addresses, class_name: "Address", join_table: "address_udt_transactions"
 
-  def self.migrate_contained_udt_ids
-    CkbTransaction.select(%i[id contained_udt_ids]).find_each do |a|
-      a.contained_udt_ids = a["contained_udt_ids"] if a["contained_udt_ids"].present?
-    end
-  end
-
-  def self.migrate_dao_address_ids
-    select(%i[id dao_address_ids]).find_in_batches do |txs|
-      res =
-        txs.reduce([]) do |memo, t|
-          memo + t[:dao_address_ids].map { |a| { address_id: a, ckb_transaction_id: t.id } }
-        end
-      AddressDaoTransaction.upsert_all(res, unique_by: [:address_id, :ckb_transaction_id]) if res.present?
-    end
-  end
-
-  def self.migrate_udt_address_ids
-    select(%i[id udt_address_ids]).find_in_batches do |txs|
-      res =
-        txs.reduce([]) do |memo, t|
-          memo + t[:udt_address_ids].map { |a| { address_id: a, ckb_transaction_id: t.id } }
-        end
-      AddressUdtTransaction.upsert_all(res, unique_by: [:address_id, :ckb_transaction_id]) if res.present?
-    end
-  end
-
   attribute :tx_hash, :ckb_hash
 
   scope :recent, -> { order("block_timestamp desc nulls last, id desc") }

--- a/app/views/api/v2/scripts/ckb_transactions.json.jbuilder
+++ b/app/views/api/v2/scripts/ckb_transactions.json.jbuilder
@@ -15,8 +15,8 @@ json.data do
     json.contained_address_ids tx.contained_address_ids
     json.tags tx.tags
     json.contained_udt_ids tx.contained_udt_ids
-    json.dao_address_ids tx.dao_address_ids
-    json.udt_address_ids tx.udt_address_ids
+    json.dao_address_ids tx.contained_dao_address_ids
+    json.udt_address_ids tx.contained_udt_address_ids
     json.bytes tx.bytes
     json.tx_status tx.tx_status
     json.display_inputs tx.display_inputs


### PR DESCRIPTION
`dao_address_ids` & `udt_address_ids` are removed from`ckb_transactions` table
change to correct name