### PR TITLE
Issue 285

### DIFF
--- a/app/jobs/revert_block_job.rb
+++ b/app/jobs/revert_block_job.rb
@@ -47,8 +47,7 @@ class RevertBlockJob < ApplicationJob
     local_tip_block.contained_addresses.each do |address|
       snapshot = snapshots.fetch(address.id, []).first
       if snapshot.present?
-        attrs = snapshot.attributes.slice("live_cells_count", "ckb_transactions_count", "dao_transactions_count",
-                                          "balance", "balance_occupied")
+        attrs = snapshot.final_state
         address.update!(attrs)
       else
         address.live_cells_count = address.cell_outputs.live.count

--- a/app/jobs/revert_block_job.rb
+++ b/app/jobs/revert_block_job.rb
@@ -43,14 +43,24 @@ class RevertBlockJob < ApplicationJob
   end
 
   def update_address_balance_and_ckb_transactions_count(local_tip_block)
+    snapshots = AddressBlockSnapshot.where.not(block_id: local_tip_block.id).where(address_id: local_tip_block.address_ids).order(block_number: :desc).distinct.group_by(&:address_id)
     local_tip_block.contained_addresses.each do |address|
-      address.live_cells_count = address.cell_outputs.live.count
-      # address.ckb_transactions_count = address.custom_ckb_transactions.count
-      address.ckb_transactions_count = AccountBook.where(address_id: address.id).count
-      address.dao_transactions_count = AddressDaoTransaction.where(address_id: address.id).count
-      address.cal_balance!
-      address.save!
+      snapshot = snapshots.fetch(address.id, []).first
+      if snapshot.present?
+        attrs = snapshot.attributes.slice("live_cells_count", "ckb_transactions_count", "dao_transactions_count",
+                                          "balance", "balance_occupied")
+        address.update!(attrs)
+      else
+        address.live_cells_count = address.cell_outputs.live.count
+        # address.ckb_transactions_count = address.custom_ckb_transactions.count
+        address.ckb_transactions_count = AccountBook.where(address_id: address.id).count
+        address.dao_transactions_count = AddressDaoTransaction.where(address_id: address.id).count
+        address.cal_balance!
+        address.save!
+      end
     end
+
+    AddressBlockSnapshot.where(block_id: local_tip_block.id).delete_all
   end
 
   def recalculate_dao_contract_transactions_count(local_tip_block)

--- a/app/models/address_block_snapshot.rb
+++ b/app/models/address_block_snapshot.rb
@@ -8,15 +8,11 @@ end
 #
 # Table name: address_block_snapshots
 #
-#  id                     :bigint           not null, primary key
-#  address_id             :bigint
-#  block_id               :bigint
-#  block_number           :bigint
-#  balance                :decimal(30, )
-#  balance_occupied       :decimal(30, )
-#  ckb_transactions_count :bigint
-#  dao_transactions_count :bigint
-#  live_cells_count       :bigint
+#  id           :bigint           not null, primary key
+#  address_id   :bigint
+#  block_id     :bigint
+#  block_number :bigint
+#  final_state  :jsonb
 #
 # Indexes
 #

--- a/app/models/address_block_snapshot.rb
+++ b/app/models/address_block_snapshot.rb
@@ -1,0 +1,26 @@
+# save the relationship of dao transactions in address
+class AddressBlockSnapshot < ApplicationRecord
+  belongs_to :block
+  belongs_to :address
+end
+
+# == Schema Information
+#
+# Table name: address_block_snapshots
+#
+#  id                     :bigint           not null, primary key
+#  address_id             :bigint
+#  block_id               :bigint
+#  block_number           :bigint
+#  balance                :decimal(30, )
+#  balance_occupied       :decimal(30, )
+#  ckb_transactions_count :bigint
+#  dao_transactions_count :bigint
+#  live_cells_count       :bigint
+#
+# Indexes
+#
+#  index_address_block_snapshots_on_address_id               (address_id)
+#  index_address_block_snapshots_on_block_id                 (block_id)
+#  index_address_block_snapshots_on_block_id_and_address_id  (block_id,address_id) UNIQUE
+#

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -587,6 +587,7 @@ module CkbSync
 
     def save_address_block_snapshot!(addr, local_block)
       AddressBlockSnapshot.create!(
+        address_id: addr.id,
         block_id: local_block.id,
         block_number: local_block.number,
         balance: addr.balance,

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -590,11 +590,13 @@ module CkbSync
         address_id: addr.id,
         block_id: local_block.id,
         block_number: local_block.number,
-        balance: addr.balance,
-        balance_occupied: addr.balance_occupied,
-        ckb_transactions_count: addr.ckb_transactions_count,
-        live_cells_count: addr.live_cells_count,
-        dao_transactions_count: addr.dao_transactions_count
+        final_state: {
+          balance: addr.balance,
+          balance_occupied: addr.balance_occupied,
+          ckb_transactions_count: addr.ckb_transactions_count,
+          live_cells_count: addr.live_cells_count,
+          dao_transactions_count: addr.dao_transactions_count
+        }
       )
     end
 

--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -92,7 +92,7 @@ module CkbSync
         # maybe can be changed to asynchronous update
         update_udt_info(local_block)
         process_dao_events!(local_block)
-        update_addresses_info(addrs_changes)
+        update_addresses_info(addrs_changes, local_block)
       end
 
       flush_inputs_outputs_caches(local_block)
@@ -533,7 +533,7 @@ module CkbSync
       CkbUtils.update_current_block_mining_info(local_block)
     end
 
-    def update_addresses_info(addrs_change)
+    def update_addresses_info(addrs_change, local_block)
       ### Backup the old upsert code
       # addrs = []
       # attributes =
@@ -580,7 +580,21 @@ module CkbSync
           live_cells_count: addr.live_cells_count + live_cells_diff,
           dao_transactions_count: addr.dao_transactions_count + dao_txs_count
         )
+
+        save_address_block_snapshot!(addr, local_block)
       end
+    end
+
+    def save_address_block_snapshot!(addr, local_block)
+      AddressBlockSnapshot.create!(
+        block_id: local_block.id,
+        block_number: local_block.number,
+        balance: addr.balance,
+        balance_occupied: addr.balance_occupied,
+        ckb_transactions_count: addr.ckb_transactions_count,
+        live_cells_count: addr.live_cells_count,
+        dao_transactions_count: addr.dao_transactions_count
+      )
     end
 
     def update_block_info!(local_block)

--- a/db/migrate/20230526085258_address_block_snapshot.rb
+++ b/db/migrate/20230526085258_address_block_snapshot.rb
@@ -1,0 +1,16 @@
+class AddressBlockSnapshot < ActiveRecord::Migration[7.0]
+  def change
+    create_table :address_block_snapshots do |t|
+      t.belongs_to :address
+      t.belongs_to :block
+      t.bigint :block_number
+      t.decimal :balance, precision: 30, scale: 0
+      t.decimal :balance_occupied, precision: 30, scale: 0
+      t.bigint :ckb_transactions_count
+      t.bigint :dao_transactions_count
+      t.bigint :live_cells_count
+
+      t.index [:block_id, :address_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20230526085258_address_block_snapshot.rb
+++ b/db/migrate/20230526085258_address_block_snapshot.rb
@@ -4,11 +4,7 @@ class AddressBlockSnapshot < ActiveRecord::Migration[7.0]
       t.belongs_to :address
       t.belongs_to :block
       t.bigint :block_number
-      t.decimal :balance, precision: 30, scale: 0
-      t.decimal :balance_occupied, precision: 30, scale: 0
-      t.bigint :ckb_transactions_count
-      t.bigint :dao_transactions_count
-      t.bigint :live_cells_count
+      t.jsonb :final_state
 
       t.index [:block_id, :address_id], unique: true
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -348,6 +348,42 @@ ALTER SEQUENCE public.account_books_id_seq OWNED BY public.account_books.id;
 
 
 --
+-- Name: address_block_snapshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.address_block_snapshots (
+    id bigint NOT NULL,
+    address_id bigint,
+    block_id bigint,
+    block_number bigint,
+    balance numeric(30,0),
+    balance_occupied numeric(30,0),
+    ckb_transactions_count bigint,
+    dao_transactions_count bigint,
+    live_cells_count bigint
+);
+
+
+--
+-- Name: address_block_snapshots_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.address_block_snapshots_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: address_block_snapshots_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.address_block_snapshots_id_seq OWNED BY public.address_block_snapshots.id;
+
+
+--
 -- Name: address_dao_transactions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2305,6 +2341,13 @@ ALTER TABLE ONLY public.account_books ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: address_block_snapshots id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.address_block_snapshots ALTER COLUMN id SET DEFAULT nextval('public.address_block_snapshots_id_seq'::regclass);
+
+
+--
 -- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2604,6 +2647,14 @@ ALTER TABLE ONLY public.witnesses ALTER COLUMN id SET DEFAULT nextval('public.wi
 
 ALTER TABLE ONLY public.account_books
     ADD CONSTRAINT account_books_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: address_block_snapshots address_block_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.address_block_snapshots
+    ADD CONSTRAINT address_block_snapshots_pkey PRIMARY KEY (id);
 
 
 --
@@ -3257,6 +3308,27 @@ CREATE UNIQUE INDEX index_account_books_on_address_id_and_ckb_transaction_id ON 
 --
 
 CREATE INDEX index_account_books_on_ckb_transaction_id ON public.account_books USING btree (ckb_transaction_id);
+
+
+--
+-- Name: index_address_block_snapshots_on_address_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_address_block_snapshots_on_address_id ON public.address_block_snapshots USING btree (address_id);
+
+
+--
+-- Name: index_address_block_snapshots_on_block_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_address_block_snapshots_on_block_id ON public.address_block_snapshots USING btree (block_id);
+
+
+--
+-- Name: index_address_block_snapshots_on_block_id_and_address_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_address_block_snapshots_on_block_id_and_address_id ON public.address_block_snapshots USING btree (block_id, address_id);
 
 
 --
@@ -4534,6 +4606,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230504023535'),
 ('20230518061651'),
 ('20230526070328'),
+('20230526085258'),
 ('20230526135653');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -356,11 +356,7 @@ CREATE TABLE public.address_block_snapshots (
     address_id bigint,
     block_id bigint,
     block_number bigint,
-    balance numeric(30,0),
-    balance_occupied numeric(30,0),
-    ckb_transactions_count bigint,
-    dao_transactions_count bigint,
-    live_cells_count bigint
+    final_state jsonb
 );
 
 

--- a/test/factories/address_block_snapshot.rb
+++ b/test/factories/address_block_snapshot.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :address_block_snapshot do
+    balance { rand((10_000_000 * 10**18)..(100_000_000 * 10**18)) }
+    balance_occupied { rand((1_000_000 * 10**18)..(10_000_000 * 10**18)) }
+    live_cells_count { rand(100..1000) }
+    ckb_transactions_count { rand(100..1000) }
+    dao_transactions_count { rand(100..1000) }
+    address
+    block
+  end
+end

--- a/test/factories/address_block_snapshot.rb
+++ b/test/factories/address_block_snapshot.rb
@@ -1,10 +1,14 @@
 FactoryBot.define do
   factory :address_block_snapshot do
-    balance { rand((10_000_000 * 10**18)..(100_000_000 * 10**18)) }
-    balance_occupied { rand((1_000_000 * 10**18)..(10_000_000 * 10**18)) }
-    live_cells_count { rand(100..1000) }
-    ckb_transactions_count { rand(100..1000) }
-    dao_transactions_count { rand(100..1000) }
+    final_state do
+      {
+        balance: 10_000_000 * 10**8,
+        balance_occupied: 1_000_000 * 10**8,
+        live_cells_count: 100,
+        ckb_transactions_count: 233,
+        dao_transactions_count: 39
+      }
+    end
     address
     block
   end

--- a/test/jobs/revert_block_job_test.rb
+++ b/test/jobs/revert_block_job_test.rb
@@ -10,25 +10,24 @@ class RevertBlockJobTest < ActiveJob::TestCase
                                                             address: @address)
     @local_block_snapshot = create(:address_block_snapshot, block: @local_block, block_number: @local_block.number,
                                                             address: @address)
-    @address.update(@local_block_snapshot.attributes.slice("live_cells_count", "ckb_transactions_count", "dao_transactions_count",
-                                                           "balance", "balance_occupied"))
+    @address.update(@local_block_snapshot.final_state)
     @parent_block_snapshot = create(:address_block_snapshot, block: parent_block, block_number: parent_block.number,
                                                              address: @address)
   end
-  test "rollback address info with parent block" do
-    assert_equal @address.reload.live_cells_count, @local_block_snapshot.live_cells_count
-    assert_equal @address.reload.ckb_transactions_count, @local_block_snapshot.ckb_transactions_count
-    assert_equal @address.reload.dao_transactions_count, @local_block_snapshot.dao_transactions_count
-    assert_equal @address.reload.balance, @local_block_snapshot.balance
-    assert_equal @address.reload.balance_occupied, @local_block_snapshot.balance_occupied
+  test "rollback address final_state with parent block" do
+    assert_equal @address.reload.live_cells_count, @local_block_snapshot.final_state["live_cells_count"]
+    assert_equal @address.reload.ckb_transactions_count, @local_block_snapshot.final_state["ckb_transactions_count"]
+    assert_equal @address.reload.dao_transactions_count, @local_block_snapshot.final_state["dao_transactions_count"]
+    assert_equal @address.reload.balance, @local_block_snapshot.final_state["balance"]
+    assert_equal @address.reload.balance_occupied, @local_block_snapshot.final_state["balance_occupied"]
 
     RevertBlockJob.new(@local_block).update_address_balance_and_ckb_transactions_count(@local_block)
 
-    assert_equal @address.reload.live_cells_count, @parent_block_snapshot.live_cells_count
-    assert_equal @address.reload.ckb_transactions_count, @parent_block_snapshot.ckb_transactions_count
-    assert_equal @address.reload.dao_transactions_count, @parent_block_snapshot.dao_transactions_count
-    assert_equal @address.reload.balance, @parent_block_snapshot.balance
-    assert_equal @address.reload.balance_occupied, @parent_block_snapshot.balance_occupied
+    assert_equal @address.reload.live_cells_count, @parent_block_snapshot.final_state["live_cells_count"]
+    assert_equal @address.reload.ckb_transactions_count, @parent_block_snapshot.final_state["ckb_transactions_count"]
+    assert_equal @address.reload.dao_transactions_count, @parent_block_snapshot.final_state["dao_transactions_count"]
+    assert_equal @address.reload.balance, @parent_block_snapshot.final_state["balance"]
+    assert_equal @address.reload.balance_occupied, @parent_block_snapshot.final_state["balance_occupied"]
 
     assert_nil AddressBlockSnapshot.find_by(id: @local_block_snapshot.id)
   end

--- a/test/jobs/revert_block_job_test.rb
+++ b/test/jobs/revert_block_job_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class RevertBlockJobTest < ActiveJob::TestCase
+  setup do
+    @address = create(:address)
+    first_block = create(:block)
+    parent_block = create(:block, parent_hash: first_block.hash, address_ids: [@address.id], number: 11)
+    @local_block = create(:block, parent_hash: parent_block.hash, address_ids: [@address.id], number: 12)
+    _first_block_snapshot = create(:address_block_snapshot, block: first_block, block_number: first_block.number,
+                                                            address: @address)
+    @local_block_snapshot = create(:address_block_snapshot, block: @local_block, block_number: @local_block.number,
+                                                            address: @address)
+    @address.update(@local_block_snapshot.attributes.slice("live_cells_count", "ckb_transactions_count", "dao_transactions_count",
+                                                           "balance", "balance_occupied"))
+    @parent_block_snapshot = create(:address_block_snapshot, block: parent_block, block_number: parent_block.number,
+                                                             address: @address)
+  end
+  test "rollback address info with parent block" do
+    assert_equal @address.reload.live_cells_count, @local_block_snapshot.live_cells_count
+    assert_equal @address.reload.ckb_transactions_count, @local_block_snapshot.ckb_transactions_count
+    assert_equal @address.reload.dao_transactions_count, @local_block_snapshot.dao_transactions_count
+    assert_equal @address.reload.balance, @local_block_snapshot.balance
+    assert_equal @address.reload.balance_occupied, @local_block_snapshot.balance_occupied
+
+    RevertBlockJob.new(@local_block).update_address_balance_and_ckb_transactions_count(@local_block)
+
+    assert_equal @address.reload.live_cells_count, @parent_block_snapshot.live_cells_count
+    assert_equal @address.reload.ckb_transactions_count, @parent_block_snapshot.ckb_transactions_count
+    assert_equal @address.reload.dao_transactions_count, @parent_block_snapshot.dao_transactions_count
+    assert_equal @address.reload.balance, @parent_block_snapshot.balance
+    assert_equal @address.reload.balance_occupied, @parent_block_snapshot.balance_occupied
+
+    assert_nil AddressBlockSnapshot.find_by(id: @local_block_snapshot.id)
+  end
+end

--- a/test/models/ckb_sync/node_data_processor_test.rb
+++ b/test/models/ckb_sync/node_data_processor_test.rb
@@ -941,7 +941,7 @@ module CkbSync
 
         address = new_local_block.contained_addresses.first
         snapshot = AddressBlockSnapshot.find_by(block_id: new_local_block.id, address_id: address.id)
-        assert_equal snapshot.live_cells_count, address.live_cells_count
+        assert_equal snapshot.final_state["live_cells_count"], address.live_cells_count
       end
     end
 
@@ -972,7 +972,7 @@ module CkbSync
 
         address = new_local_block.contained_addresses.first
         snapshot = AddressBlockSnapshot.find_by(block_id: new_local_block.id, address_id: address.id)
-        assert_equal snapshot.balance, address.balance
+        assert_equal snapshot.final_state["balance"], address.balance
       end
     end
 

--- a/test/models/ckb_sync/node_data_processor_test.rb
+++ b/test/models/ckb_sync/node_data_processor_test.rb
@@ -938,6 +938,10 @@ module CkbSync
         new_local_block = node_data_processor.call
 
         assert_equal origin_live_cells_count + 1, new_local_block.contained_addresses.sum(:live_cells_count)
+
+        address = new_local_block.contained_addresses.first
+        snapshot = AddressBlockSnapshot.find_by(block_id: new_local_block.id, address_id: address.id)
+        assert_equal snapshot.live_cells_count, address.live_cells_count
       end
     end
 
@@ -965,6 +969,10 @@ module CkbSync
 
         assert_equal origin_balance + new_local_block.cell_outputs.sum(:capacity),
                      new_local_block.contained_addresses.sum(:balance)
+
+        address = new_local_block.contained_addresses.first
+        snapshot = AddressBlockSnapshot.find_by(block_id: new_local_block.id, address_id: address.id)
+        assert_equal snapshot.balance, address.balance
       end
     end
 


### PR DESCRIPTION
Create a table to save every block's address info data.
When a block rollback, we can get last address's info from this table and no need to calculate in realtime. 