### PR TITLE
fix: remove duplicate cell datum when importing pending transactions

### DIFF
--- a/app/jobs/import_transaction_job.rb
+++ b/app/jobs/import_transaction_job.rb
@@ -106,9 +106,6 @@ class ImportTransactionJob < ApplicationJob
         status: "pending"
       )
 
-      if output_data.present? && output_data != "0x"
-        (cell.cell_datum || cell.build_cell_datum).update(data: [output_data[2..]].pack("H*"))
-      end
       process_output cell
       process_deployed_cell(cell.lock_script)
       process_deployed_cell(cell.type_script) if cell.type_script

--- a/lib/websocket.rb
+++ b/lib/websocket.rb
@@ -48,13 +48,6 @@ persister =
           })
         rescue StandardError => e
           Rails.logger.error "Error occurred during ImportTransactionJob data: #{data}, error: #{e.message}"
-          Sentry.capture_message(
-            "Import pending transaction",
-            extra: {
-              tx_hash: data["transaction"]["hash"],
-              timestamp: data["timestamp"].hex
-            }
-          )
         end
       end
     end


### PR DESCRIPTION
https://github.com/nervosnetwork/ckb-explorer/blob/develop/app/models/cell_output.rb#L84

has already create cell datum.

Cell does not reload, so repeated creation will cause errors: 
```bash
 error: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "cell_data_pkey"
DETAIL:  Key (cell_output_id)=(1263805) already exists.
```
