### PR TITLE
chore: adjust the date parameter to a timestamp

### DIFF
--- a/app/controllers/api/v1/address_transactions_controller.rb
+++ b/app/controllers/api/v1/address_transactions_controller.rb
@@ -1,4 +1,3 @@
-require "csv"
 module Api
   module V1
     class AddressTransactionsController < ApplicationController

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -1,4 +1,3 @@
-require "csv"
 module Api
   module V1
     class BlocksController < ApplicationController

--- a/app/controllers/api/v1/udts_controller.rb
+++ b/app/controllers/api/v1/udts_controller.rb
@@ -1,4 +1,3 @@
-require "csv"
 module Api
   module V1
     class UdtsController < ApplicationController

--- a/app/jobs/csv_exportable/base_exporter.rb
+++ b/app/jobs/csv_exportable/base_exporter.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 module CsvExportable
   class BaseExporter < ApplicationJob
     def perform(*)

--- a/app/jobs/csv_exportable/export_address_transactions_job.rb
+++ b/app/jobs/csv_exportable/export_address_transactions_job.rb
@@ -7,12 +7,12 @@ module CsvExportable
         limit(5000)
 
       if args[:start_date].present?
-        start_date = DateTime.strptime(args[:start_date], "%Y-%m-%d").to_time.to_i * 1000
+        start_date = BigDecimal(args[:start_date])
         tx_ids = tx_ids.where("ckb_transactions.block_timestamp >= ?", start_date)
       end
 
       if args[:end_date].present?
-        end_date = DateTime.strptime(args[:end_date], "%Y-%m-%d").to_time.to_i * 1000
+        end_date = BigDecimal(args[:end_date])
         tx_ids = tx_ids.where("ckb_transactions.block_timestamp <= ?", end_date)
       end
 

--- a/app/jobs/csv_exportable/export_address_transactions_job.rb
+++ b/app/jobs/csv_exportable/export_address_transactions_job.rb
@@ -65,7 +65,7 @@ module CsvExportable
         token_out = output_capacities[unit]
 
         balance_change = token_out.to_f - token_in.to_f
-        method = balance_change.positive? ? "PAYMENT RECEIVED" : "PAYMENT SENT"
+        method = balance_change.negative? ? "PAYMENT SENT" : "PAYMENT RECEIVED"
         display_fee = units.length == 1 || (units.length > 1 && unit == "CKB")
 
         rows << [

--- a/app/jobs/csv_exportable/export_block_transactions_job.rb
+++ b/app/jobs/csv_exportable/export_block_transactions_job.rb
@@ -7,12 +7,12 @@ module CsvExportable
                             :live_cell_changes, :updated_at)
 
       if args[:start_date].present?
-        start_date = DateTime.strptime(args[:start_date], "%Y-%m-%d").to_time.to_i * 1000
+        start_date = BigDecimal(args[:start_date])
         blocks = blocks.where("timestamp >= ?", start_date)
       end
 
       if args[:end_date].present?
-        end_date = DateTime.strptime(args[:end_date], "%Y-%m-%d").to_time.to_i * 1000
+        end_date = BigDecimal(args[:end_date])
         blocks = blocks.where("timestamp <= ?", end_date)
       end
 

--- a/app/jobs/csv_exportable/export_nft_transactions_job.rb
+++ b/app/jobs/csv_exportable/export_nft_transactions_job.rb
@@ -8,12 +8,12 @@ module CsvExportable
         where("token_items.collection_id = ?", collection.id)
 
       if args[:start_date].present?
-        start_date = DateTime.strptime(args[:start_date], "%Y-%m-%d").to_time.to_i * 1000
+        start_date = BigDecimal(args[:start_date])
         token_transfers = token_transfers.where("ckb_transactions.block_timestamp >= ?", start_date)
       end
 
       if args[:end_date].present?
-        end_date = DateTime.strptime(args[:end_date], "%Y-%m-%d").to_time.to_i * 1000
+        end_date = BigDecimal(args[:end_date])
         token_transfers = token_transfers.where("ckb_transactions.block_timestamp <= ?", end_date)
       end
 

--- a/app/jobs/csv_exportable/export_udt_transactions_job.rb
+++ b/app/jobs/csv_exportable/export_udt_transactions_job.rb
@@ -65,7 +65,7 @@ module CsvExportable
         token_out = output_capacities[address_hash]
 
         balance_change = token_out.to_f - token_in.to_f
-        method = balance_change.positive? ? "PAYMENT RECEIVED" : "PAYMENT SENT"
+        method = balance_change.negative? ? "PAYMENT SENT" : "PAYMENT RECEIVED"
 
         rows << [
           transaction.tx_hash,

--- a/app/jobs/csv_exportable/export_udt_transactions_job.rb
+++ b/app/jobs/csv_exportable/export_udt_transactions_job.rb
@@ -5,12 +5,12 @@ module CsvExportable
       ckb_transactions = udt.ckb_transactions
 
       if args[:start_date].present?
-        start_date = DateTime.strptime(args[:start_date], "%Y-%m-%d").to_time.to_i * 1000
+        start_date = BigDecimal(args[:start_date])
         ckb_transactions = ckb_transactions.where("block_timestamp >= ?", start_date)
       end
 
       if args[:end_date].present?
-        end_date = DateTime.strptime(args[:end_date], "%Y-%m-%d").to_time.to_i * 1000
+        end_date = BigDecimal(args[:end_date])
         ckb_transactions = ckb_transactions.where("block_timestamp <= ?", end_date)
       end
 

--- a/test/controllers/api/v1/address_transactions_controller_test.rb
+++ b/test/controllers/api/v1/address_transactions_controller_test.rb
@@ -481,8 +481,8 @@ module Api
                                                                     transaction_fee: 1000)
         valid_get download_csv_api_v1_address_transactions_url(
           id: address.address_hash,
-          start_date: "2020-01-01",
-          end_date: Date.today.to_s
+          start_date: "2020-01-01".to_time.to_i * 1000,
+          end_date: Date.today.to_time.to_i * 1000
         )
 
         csv_data = CSV.parse(response.body)

--- a/test/controllers/api/v1/blocks_controller_test.rb
+++ b/test/controllers/api/v1/blocks_controller_test.rb
@@ -304,7 +304,7 @@ module Api
 
         block = create :block, timestamp: Time.now.to_i * 1000, miner_hash: 'ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqwau7qpcpealv6xf3a37pdcq6ajhwuyaxgs5g955'
 
-        valid_get download_csv_api_v1_blocks_url(start_date: 1.day.ago.strftime("%Y-%m-%d"))
+        valid_get download_csv_api_v1_blocks_url(start_date: 1.day.ago.to_i * 1000)
         assert_response :success
       end
 

--- a/test/controllers/api/v1/udts_controller_test.rb
+++ b/test/controllers/api/v1/udts_controller_test.rb
@@ -409,9 +409,8 @@ module Api
 
       test "should get download_csv" do
         udt = create(:udt, :with_transactions, published: true)
-
-        valid_get download_csv_api_v1_udts_url(id: udt.type_hash, start_date: Time.now.strftime("%Y-%m-%d"),
-                                               end_date: Time.now.strftime("%Y-%m-%d"))
+        valid_get download_csv_api_v1_udts_url(id: udt.type_hash, start_date: Time.now.to_i * 1000,
+                                               end_date: Time.now.to_i * 1000)
 
         assert_response :success
       end

--- a/test/controllers/api/v2/nft/transfers_controller_test.rb
+++ b/test/controllers/api/v2/nft/transfers_controller_test.rb
@@ -35,13 +35,11 @@ module Api
       end
 
       test "should get download_csv, by date" do
-
-        valid_get download_csv_api_v2_nft_transfers_url(collection_id: @token_collection.sn, start_date: 1.day.ago.strftime("%Y-%m-%d"))
+        valid_get download_csv_api_v2_nft_transfers_url(collection_id: @token_collection.sn, start_date: 1.day.ago.to_i * 1000)
         assert_response :success
       end
 
       test "should get download_csv, by block_number" do
-
         valid_get download_csv_api_v2_nft_transfers_url(collection_id: @token_collection.sn, start_number: 8, end_number: 12)
         assert_response :success
       end


### PR DESCRIPTION
Because the page displays the local time, the database comparison is utc, so the time zone conversion is performed directly on the front end.