### PR TITLE
fix: filter dao transactions by address hash

### DIFF
--- a/app/controllers/api/v1/contract_transactions_controller.rb
+++ b/app/controllers/api/v1/contract_transactions_controller.rb
@@ -23,8 +23,8 @@ module Api
             address = Address.find_address!(params[:address_hash])
             raise Api::V1::Exceptions::AddressNotFoundError if address.is_a?(NullAddress)
 
-            ckb_transactions = ckb_transactions.includes(:contained_dao_addresses).
-              where(address_dao_transactions: { address_id: address.id })
+            ckb_transactions = ckb_transactions.joins(:account_books).
+              where(account_books: { address_id: address.id })
           end
 
           ckb_transactions = ckb_transactions.page(@page).per(@page_size).fast_page

--- a/test/controllers/api/v1/contract_transactions_controller_test.rb
+++ b/test/controllers/api/v1/contract_transactions_controller_test.rb
@@ -209,8 +209,8 @@ module Api
         address = create(:address)
         fake_dao_deposit_transaction(15, address)
 
-        contract_ckb_transactions = address.ckb_dao_transactions.includes(:contained_dao_addresses).
-          where(address_dao_transactions: { address_id: address.id }).
+        contract_ckb_transactions = address.ckb_dao_transactions.joins(:account_books).
+          where(account_books: { address_id: address.id }).
           order("ckb_transactions.block_timestamp desc nulls last, ckb_transactions.id desc").page(page).per(page_size).fast_page
 
         valid_get api_v1_contract_transaction_url(DaoContract::CONTRACT_NAME),


### PR DESCRIPTION
The `address_dao_transactions` table only stores cell data whose cell_type is `nervos_dao_deposit` and `nervos_dao_withdrawing`. So there is no way to filter other types of cells by address.