### PR TITLE
Issue 395 8

### DIFF
--- a/app/workers/token_transfer_detect_worker.rb
+++ b/app/workers/token_transfer_detect_worker.rb
@@ -156,6 +156,7 @@ class TokenTransferDetectWorker
     spore_cluster_cell = spore_cluster_type.cell_outputs.order("id desc").first
     if spore_cluster_cell.present? && coll.cell_id.blank?
       parsed_cluster_data = CkbUtils.parse_spore_cluster_data(spore_cluster_cell.data)
+      coll.creator_id = spore_cluster_cell.address_id
       coll.cell_id = spore_cluster_cell.id
       coll.name = parsed_cluster_data[:name]
       coll.description = parsed_cluster_data[:description]


### PR DESCRIPTION
The CleanUpWorker will auto remove creator_id were nil's records. So we need to save creator_id when create token collection.