### PR TITLE
fix: current exist no binded type script that cause wrong query

### DIFF
--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -779,7 +779,7 @@ dao_address_ids, contained_udt_ids, contained_addr_ids
             contract = Contract.create code_hash: lock_script.script_hash
             temp_hash = temp_hash.merge contract_id: contract.id
           end
-          script = Script.create_or_find_by temp_hash
+          script = Script.find_or_create_by temp_hash
           lock_script.update script_id: script.id
         end
       end
@@ -798,7 +798,7 @@ dao_address_ids, contained_udt_ids, contained_addr_ids
             contract = Contract.create code_hash: type_script.script_hash
             temp_hash = temp_hash.merge contract_id: contract.id
           end
-          script = Script.create_or_find_by temp_hash
+          script = Script.find_or_create_by temp_hash
           type_script.update script_id: script.id
         end
       end
@@ -1401,7 +1401,7 @@ tags, udt_address_ids, dao_address_ids, contained_udt_ids, contained_addr_ids, a
       return if cellbase.witnesses.blank?
 
       lock_script = CkbUtils.generate_lock_script_from_cellbase(cellbase)
-      lock = LockScript.create_or_find_by(
+      lock = LockScript.find_or_create_by(
         code_hash: lock_script.code_hash,
         hash_type: lock_script.hash_type,
         args: lock_script.args

--- a/app/models/lock_script.rb
+++ b/app/models/lock_script.rb
@@ -23,7 +23,7 @@ class LockScript < ApplicationRecord
     create_with(
       script_hash: lock_hash,
       address: address
-    ).create_or_find_by!(
+    ).find_or_create_by!(
       code_hash: sdk_lock.code_hash,
       hash_type: sdk_lock.hash_type,
       args: sdk_lock.args

--- a/app/models/script.rb
+++ b/app/models/script.rb
@@ -21,7 +21,7 @@ class Script < ActiveRecord::Base
         temp_hash = temp_hash.merge is_contract: true, contract_id: contract_id
       end
 
-      script = Script.create_or_find_by temp_hash
+      script = Script.find_or_create_by temp_hash
       type_script.update script_id: script.id
     end
 
@@ -32,7 +32,7 @@ class Script < ActiveRecord::Base
       if contract_id
         temp_hash = temp_hash.merge is_contract: true, contract_id: contract_id
       end
-      script = Script.create_or_find_by temp_hash
+      script = Script.find_or_create_by temp_hash
       lock_script.update script_id: script.id
     end
 

--- a/app/models/type_script.rb
+++ b/app/models/type_script.rb
@@ -16,7 +16,7 @@ class TypeScript < ApplicationRecord
     # script = Script
     create_with(
       script_hash: type_hash
-    ).create_or_find_by(
+    ).find_or_create_by(
       code_hash: sdk_type.code_hash,
       hash_type: sdk_type.hash_type,
       args: sdk_type.args


### PR DESCRIPTION
The same type script exist 4 records in our database.So find_by is not correct.