### PR TITLE
fix: optimize transaction display cells cache key

### DIFF
--- a/app/serializers/ckb_transactions_serializer.rb
+++ b/app/serializers/ckb_transactions_serializer.rb
@@ -24,7 +24,8 @@ class CkbTransactionsSerializer
   end
 
   attribute :display_inputs do |object, params|
-    Rails.cache.fetch("display_inputs_previews_#{params[:previews].present?}_#{object.id}", expires_in: 1.day) do
+    cache_key = "display_inputs_previews_#{params[:previews].present?}_#{object.id}_#{object.inputs.cache_key}"
+    Rails.cache.fetch(cache_key, expires_in: 1.day) do
       if params && params[:previews]
         object.display_inputs(previews: true)
       else
@@ -34,7 +35,8 @@ class CkbTransactionsSerializer
   end
 
   attribute :display_outputs do |object, params|
-    Rails.cache.fetch("display_outputs_previews_#{params[:previews].present?}_#{object.id}", expires_in: 1.day) do
+    cache_key = "display_outputs_previews_#{params[:previews].present?}_#{object.id}_#{object.outputs.cache_key}"
+    Rails.cache.fetch(cache_key, expires_in: 1.day) do
       if params && params[:previews]
         object.display_outputs(previews: true)
       else

--- a/test/controllers/api/v1/suggest_queries_controller_test.rb
+++ b/test/controllers/api/v1/suggest_queries_controller_test.rb
@@ -190,7 +190,7 @@ module Api
         type_script = create(
           :type_script,
           code_hash: Settings.type_id_code_hash,
-          args: "0x2ab17f74009a9948ae2d3623dac853cc3ff1ef8270304ea5d9980b1f2b6810d5",
+          args: "0x8536c9d5d908bd89fc70099e4284870708b6632356aad98734fcf43f6f71c304",
           script_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"
         )
         response_json = TypeScriptSerializer.new(type_script).serialized_json


### PR DESCRIPTION
Because the redis configuration of node processor is different from the configuration of explorer api, only the cache key can be adjusted here.