### PR TITLE
chore: remove sentry transaction performance tracer

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,14 +1,6 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
-  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
-
-  # Set tracesSampleRate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  # We recommend adjusting this value in production
-  config.traces_sample_rate = ENV.fetch("SENTRY_SAMPLE_RATE", 1.0).to_f
-  config.traces_sampler = lambda do |context|
-    true
-  end    
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.logger = Logger.new(STDERR)
   config.enabled_environments = %w[production staging]
 end


### PR DESCRIPTION
There were too many sentry transaction logs sent.And we only use new relic to watch performance.