### PR TITLE
Issue 527 3

### DIFF
--- a/app/controllers/api/v1/address_udt_transactions_controller.rb
+++ b/app/controllers/api/v1/address_udt_transactions_controller.rb
@@ -9,8 +9,8 @@ module Api
         raise Api::V1::Exceptions::AddressNotFoundError if address.is_a?(NullAddress)
         raise Api::V1::Exceptions::TypeHashInvalidError if params[:type_hash].blank?
 
-        udt = Udt.find_by(type_hash: params[:type_hash])
-        raise Api::V1::Exceptions::UdtNotFoundError if udt.blank? || (udt.udt_type != "omiga_inscription" && !udt.published)
+        udt = Udt.find_by(type_hash: params[:type_hash], published: true)
+        raise Api::V1::Exceptions::UdtNotFoundError if udt.blank?
 
         ckb_dao_transactions = address.ckb_udt_transactions(udt.id).
           select(:id, :tx_hash, :block_id, :block_number, :block_timestamp, :is_cellbase, :updated_at, :created_at).

--- a/app/controllers/api/v1/udt_transactions_controller.rb
+++ b/app/controllers/api/v1/udt_transactions_controller.rb
@@ -4,8 +4,8 @@ module Api
       before_action :validate_query_params, :validate_pagination_params, :pagination_params
 
       def show
-        udt = Udt.find_by(type_hash: params[:id])
-        raise Api::V1::Exceptions::UdtNotFoundError if udt.blank? || (udt.udt_type != "omiga_inscription" && !udt.published)
+        udt = Udt.find_by(type_hash: params[:id], published: true)
+        raise Api::V1::Exceptions::UdtNotFoundError if udt.blank?
 
         ckb_transactions = udt.ckb_transactions.tx_committed.
           select(:id, :tx_hash, :block_id, :block_number,

--- a/app/models/omiga_inscription_info.rb
+++ b/app/models/omiga_inscription_info.rb
@@ -8,22 +8,23 @@ end
 #
 # Table name: omiga_inscription_infos
 #
-#  id              :bigint           not null, primary key
-#  code_hash       :binary
-#  hash_type       :string
-#  args            :string
-#  decimal         :decimal(, )
-#  name            :string
-#  symbol          :string
-#  udt_hash        :string
-#  expected_supply :decimal(, )
-#  mint_limit      :decimal(, )
-#  mint_status     :integer
-#  udt_id          :bigint
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  type_hash       :binary
-#  pre_udt_hash    :binary
+#  id                 :bigint           not null, primary key
+#  code_hash          :binary
+#  hash_type          :string
+#  args               :string
+#  decimal            :decimal(, )
+#  name               :string
+#  symbol             :string
+#  udt_hash           :string
+#  expected_supply    :decimal(, )
+#  mint_limit         :decimal(, )
+#  mint_status        :integer
+#  udt_id             :bigint
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  type_hash          :binary
+#  pre_udt_hash       :binary
+#  is_repeated_symbol :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/serializers/udt_serializer.rb
+++ b/app/serializers/udt_serializer.rb
@@ -61,4 +61,10 @@ class UdtSerializer
   } do |object|
     object.omiga_inscription_info.pre_udt_hash
   end
+
+  attribute :is_repeated_symbol, if: Proc.new { |record, _params|
+    record.udt_type == "omiga_inscription"
+  } do |object|
+    object.omiga_inscription_info.is_repeated_symbol
+  end
 end

--- a/db/migrate/20240313075641_add_is_repeated_symbol_to_omiga_inscription_info.rb
+++ b/db/migrate/20240313075641_add_is_repeated_symbol_to_omiga_inscription_info.rb
@@ -1,0 +1,5 @@
+class AddIsRepeatedSymbolToOmigaInscriptionInfo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :omiga_inscription_infos, :is_repeated_symbol, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1810,7 +1810,8 @@ CREATE TABLE public.omiga_inscription_infos (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     type_hash bytea,
-    pre_udt_hash bytea
+    pre_udt_hash bytea,
+    is_repeated_symbol boolean DEFAULT false
 );
 
 
@@ -5185,6 +5186,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240301025505'),
 ('20240305100337'),
 ('20240311143030'),
-('20240312050057');
+('20240312050057'),
+('20240313075641');
 
 

--- a/test/controllers/api/v1/address_udt_transactions_controller_test.rb
+++ b/test/controllers/api/v1/address_udt_transactions_controller_test.rb
@@ -238,7 +238,7 @@ module Api
       end
 
       test "should return meta if udt is omiga_inscription" do
-        udt = create(:udt, udt_type: :omiga_inscription, published: false)
+        udt = create(:udt, udt_type: :omiga_inscription, published: true)
         address = create(:address, :with_udt_transactions, transactions_count: 3, udt:)
 
         valid_get api_v1_address_udt_transaction_url(address.address_hash, type_hash: udt.type_hash)

--- a/test/controllers/api/v1/omiga_inscriptions_controller_test.rb
+++ b/test/controllers/api/v1/omiga_inscriptions_controller_test.rb
@@ -72,7 +72,7 @@ module Api
         assert_equal %w(
           symbol full_name display_name uan total_amount addresses_count
           decimal icon_file h24_ckb_transactions_count created_at description
-          published type_hash type_script issuer_address mint_status mint_limit expected_supply inscription_info_id udt_type pre_udt_hash info_type_hash operator_website email
+          published type_hash type_script issuer_address mint_status mint_limit expected_supply inscription_info_id udt_type pre_udt_hash info_type_hash operator_website email is_repeated_symbol
         ).sort,
                      response_udt["attributes"].keys.sort
       end
@@ -86,7 +86,7 @@ module Api
         assert_equal %w(
           symbol full_name display_name uan total_amount addresses_count
           decimal icon_file h24_ckb_transactions_count created_at description
-          published type_hash type_script issuer_address mint_status mint_limit expected_supply inscription_info_id udt_type pre_udt_hash info_type_hash operator_website email
+          published type_hash type_script issuer_address mint_status mint_limit expected_supply inscription_info_id udt_type pre_udt_hash info_type_hash operator_website email is_repeated_symbol
         ).sort,
                      response_udt["attributes"].keys.sort
       end

--- a/test/models/ckb_sync/node_data_processor_test.rb
+++ b/test/models/ckb_sync/node_data_processor_test.rb
@@ -4047,7 +4047,7 @@ module CkbSync
         udt = Udt.first
         assert_equal "0x5fa66c8d5f43914f85d3083e0529931883a5b0a14282f891201069f1b5067908",
                      udt.type_hash
-        assert_equal true, udt.published
+        assert_equal false, info.is_repeated_symbol
       end
     end
 
@@ -4148,7 +4148,7 @@ module CkbSync
         node_data_processor.process_block(node_block)
         assert_equal 2, Udt.count
         assert_equal info.udt_hash, OmigaInscriptionInfo.last.pre_udt_hash
-        assert_equal true, Udt.last.published
+        assert_equal false, OmigaInscriptionInfo.last.is_repeated_symbol
       end
     end
 


### PR DESCRIPTION
Before we use udt's  published attribute to mark a omiga inscription is repeated symbol or not. But the published value was used in other code and confused us. So we add a new attribute in omiga inscription info table to check omiga inscription was repeated or not.