### PR TITLE
refactor: use block_timestamp index is very slow, query ids first then

### DIFF
--- a/app/interactions/addresses/live_cells.rb
+++ b/app/interactions/addresses/live_cells.rb
@@ -13,9 +13,15 @@ module Addresses
       raise AddressNotFoundError if address.is_a?(NullAddress)
 
       order_by, asc_or_desc = live_cells_ordering
-      records = CellOutput.live.where(address_id: address.map(&:id)).
-        order(order_by => asc_or_desc).
-        page(page).per(page_size).fast_page
+      records =
+        if order_by == "block_timestamp"
+          ids = CellOutput.live.where(address_id: address.map(&:id)).pluck(:id)
+          CellOutput.where(id: ids).order(order_by => asc_or_desc).page(page).per(page_size).fast_page
+        else
+          CellOutput.live.where(address_id: address.map(&:id)).
+            order(order_by => asc_or_desc).
+            page(page).per(page_size).fast_page
+        end
       options = FastJsonapi::PaginationMetaGenerator.new(
         request:, records:, page:, page_size:,
       ).call


### PR DESCRIPTION
order