### PR TITLE
chore: Fix the incorrect field names in the test file

### DIFF
--- a/test/utils/ckb_utils_test.rb
+++ b/test/utils/ckb_utils_test.rb
@@ -454,7 +454,7 @@ class CkbUtilsTest < ActiveSupport::TestCase
     info = CkbUtils.parse_unique_cell(data)
     assert_equal info[:decimal], 8
     assert_equal info[:name], "Unique BBQ"
-    assert_nil info[:sybol]
+    assert_nil info[:symbol]
   end
 
   test "calculate commitment with single input and output including typescript" do


### PR DESCRIPTION
Fix the incorrect field names in the test file