### PR TITLE
HOTFIX: Prevent missing UDT records from stopping block sync

### DIFF
--- a/app/models/ckb_sync/new_node_data_processor.rb
+++ b/app/models/ckb_sync/new_node_data_processor.rb
@@ -427,8 +427,16 @@ module CkbSync
           when "spore_cell", "did_cell"
             udt_output.type_script.args.hex
           end
-        udt = Udt.where(type_hash: udt_output.type_hash, udt_type:).select(:id, :udt_type, :full_name,
-                                                                           :symbol, :decimal, :published, :code_hash, :type_hash, :created_at).take!
+        udt = Udt.where(type_hash: udt_output.type_hash, udt_type:).select(
+          :id, :udt_type, :full_name, :symbol, :decimal, :published, :code_hash, :type_hash, :created_at,
+        ).first
+        unless udt
+          Rails.logger.error(
+            "Missing Udt, skip udt account update: cell_output_id=#{udt_output.id}, " \
+            "cell_type=#{udt_output.cell_type}, type_hash=#{udt_output.type_hash}, udt_type=#{udt_type}",
+          )
+          next
+        end
         if udt_account.present?
           udt_accounts_attributes << { id: udt_account.id, amount:,
                                        created_at: udt.created_at }
@@ -450,8 +458,16 @@ module CkbSync
           udt_account = UdtAccount.where(address_id: udt_output.address_id).where(type_hash: udt_output.type_hash, udt_type:).select(:id,
                                                                                                       :created_at).first
           amount = udt_account_amount(udt_type, udt_output.type_hash, udt_output.address_id)
-          udt = Udt.where(type_hash: udt_output.type_hash, udt_type:).select(:id, :udt_type, :full_name,
-                                                                             :symbol, :decimal, :published, :code_hash, :type_hash, :created_at).take!
+          udt = Udt.where(type_hash: udt_output.type_hash, udt_type:).select(
+            :id, :udt_type, :full_name, :symbol, :decimal, :published, :code_hash, :type_hash, :created_at,
+          ).first
+          unless udt
+            Rails.logger.error(
+              "Missing Udt, skip udt account update: cell_output_id=#{udt_output.id}, " \
+              "cell_type=#{udt_output.cell_type}, type_hash=#{udt_output.type_hash}, udt_type=#{udt_type}",
+            )
+            next
+          end
           if udt_account.present?
             case udt_type
             when "sudt", "ssri", "omiga_inscription", "xudt", "xudt_compatible"
@@ -675,7 +691,7 @@ module CkbSync
           contained_addr_ids[tx_index].to_a.map do |address_id|
             { address_id:, ckb_transaction_id: tx_id, income: addr_tx_changes[tx_index][address_id], block_number: tx["block_number"], tx_index: }
           end
-        full_tx_udt_ids += contained_udt_ids[tx_index].to_a.map do |u|
+        full_tx_udt_ids += contained_udt_ids[tx_index].to_a.compact.map do |u|
           { udt_id: u, ckb_transaction_id: tx_id }
         end
         full_udt_address_ids += udt_address_ids[tx_index].to_a.map do |a|

--- a/test/models/ckb_sync/node_data_processor_test.rb
+++ b/test/models/ckb_sync/node_data_processor_test.rb
@@ -1734,6 +1734,55 @@ module CkbSync
       end
     end
 
+    test "process_block skips a missing historical xudt without rolling back" do
+      prepare_node_data(10)
+      VCR.use_cassette("blocks/#{DEFAULT_NODE_BLOCK_NUMBER}") do
+        node_block = CkbSync::Api.instance.get_block_by_number(DEFAULT_NODE_BLOCK_NUMBER)
+        historical_block = create(:block, :with_block_hash, number: node_block.header.number - 1)
+        historical_tx = create(:ckb_transaction, block: historical_block)
+        type_script = create(:type_script, code_hash: Settings.xudt_data_hash, hash_type: "data1")
+        historical_output = create(
+          :cell_output,
+          block: historical_block,
+          ckb_transaction: historical_tx,
+          tx_hash: historical_tx.tx_hash,
+          cell_index: 0,
+          capacity: 1_000 * (10**8),
+          cell_type: "xudt",
+          type_hash: type_script.script_hash,
+          type_script:,
+        )
+        input = CKB::Types::Input.new(
+          previous_output: CKB::Types::OutPoint.new(tx_hash: historical_output.tx_hash, index: 0),
+        )
+        output = CKB::Types::Output.new(
+          capacity: 150 * (10**8),
+          lock: CKB::Types::Script.new(
+            code_hash: Settings.secp_cell_type_hash,
+            args: "0x#{SecureRandom.hex(20)}",
+            hash_type: "type",
+          ),
+          type: nil,
+        )
+        consuming_tx = CKB::Types::Transaction.new(
+          hash: "0x#{SecureRandom.hex(32)}",
+          inputs: [input],
+          outputs: [output],
+          outputs_data: ["0x"],
+        )
+        node_block.transactions << consuming_tx
+
+        assert_no_difference -> { Udt.count } do
+          node_data_processor.process_block(node_block)
+        end
+
+        local_tx = CkbTransaction.find_by!(tx_hash: consuming_tx.hash)
+        assert_not Udt.exists?(type_hash: type_script.script_hash)
+        assert_not UdtTransaction.exists?(ckb_transaction_id: local_tx.id)
+        assert historical_output.reload.dead?
+      end
+    end
+
     test "#process_block should create one udt when there is one m_nft_token cell" do
       create(:address)
       prepare_node_data(10)


### PR DESCRIPTION
## Summary

- Replace both strict `Udt` lookups in `update_or_create_udt_accounts!` with non-raising lookups.
- Log the missing `CellOutput`, cell type, type hash, and expected UDT type, then skip only that UDT account update.
- Filter missing UDT IDs before writing `UdtTransaction` relationships.
- Add a full `process_block` regression test for a consumed historical xUDT whose `Udt` row is missing.

## Root cause

Explorer contains a historical `CellOutput` classified as `xudt` without a matching `Udt` row. When block `20,169,277` consumes that output, `update_or_create_udt_accounts!` calls `take!`, raises `ActiveRecord::RecordNotFound`, rolls back the block transaction, and terminates the blocksyncer. Restarting retries the same block and fails again.

## Impact

After deployment and a blocksyncer restart, this narrow historical inconsistency no longer blocks synchronization. The affected UDT account update and transaction relationship are intentionally skipped, and the missing `Udt` is not fabricated in the sync hot path.

This is an emergency tolerance fix. A separate follow-up should backfill and verify the missing historical UDT data.

## Validation

- [x] Production-path regression: 1 run, 4 assertions, 0 failures, 0 errors
- [x] `test/models/ckb_sync/node_data_processor_test.rb`: 119 runs, 207 assertions, 0 failures, 0 errors
- [x] Ruby syntax checks pass for both changed files
- [x] `git diff --check` passes
